### PR TITLE
[MRG] Updated zapier script to handle decimals above 1 million

### DIFF
--- a/etc/zapier.py
+++ b/etc/zapier.py
@@ -41,9 +41,9 @@ def millify(n):
     #  - 967123  -> 967k
     #  - 1000123 -> 1M
     #  - 1100123 -> 1.1M
-    final_string = one_decimal if n > 1e6 and not one_decimal.is_integer() else int(final_num)
+    final_output = one_decimal if n > 1e6 and not one_decimal.is_integer() else int(final_num)
 
-    return f'{final_string}{millnames[millidx]}'
+    return f'{final_output}{millnames[millidx]}'
 
 
 # Open a session to save time (only allowed 1 second on Zapier)


### PR DESCRIPTION

# Description

Seeing as we will hit 1 million downloads soon, I updated the Zapier script to include 1 decimal, if there is one (only above 1 million downloads). The previous behavior would have shown `1M` all the way up until `2M`. The new behavior will increment every 100,000 downloads.

Additionally, I changed to using f-strings, because they are [faster](https://realpython.com/python-f-strings/#speed)

### Old behavior
|Downloads|Badge Output|
|---|---|
|967123|967k|
|1000123|1M|
|1100123|1M|

### New Behavior
|Downloads|Badge Output|
|---|---|
|967123|967k|
|1000123|1M|
|1100123|1.1M|

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Tested on the above input samples

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
