### PR TITLE
[MRG+1] General cleanup

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -74,6 +74,18 @@ Differencing helpers
     arima.nsdiffs
 
 
+Seasonal decomposition
+----------------------
+
+.. currentmodule:: pmdarima
+
+.. autosummary::
+    :toctree: generated/
+    :template: function.rst
+
+    arima.decompose
+
+
 .. _datasets_ref:
 
 :mod:`pmdarima.datasets`: Toy timeseries datasets

--- a/pmdarima/__init__.py
+++ b/pmdarima/__init__.py
@@ -46,7 +46,7 @@ else:
     from . import __check_build
 
     # Stuff we want at top-level
-    from .arima import auto_arima, ARIMA, AutoARIMA, StepwiseContext
+    from .arima import auto_arima, ARIMA, AutoARIMA, StepwiseContext, decompose
     from .utils import acf, autocorr_plot, c, pacf, plot_acf, plot_pacf
 
     # Need these namespaces at the top so they can be used like:
@@ -64,12 +64,13 @@ else:
         'preprocessing',
         'utils',
 
-        # Function(s) at top level
+        # Functions & non-modules at top level
         'ARIMA',
         'acf',
         'autocorr_plot',
         'auto_arima',
         'c',
+        'decompose',
         'pacf',
         'plot_acf',
         'plot_pacf',

--- a/pmdarima/arima/__init__.py
+++ b/pmdarima/arima/__init__.py
@@ -9,6 +9,7 @@ from .utils import *
 from .warnings import *
 
 # These need to be top-level since 0.7.0 for the documentation
+from .seasonality import decompose
 from .seasonality import CHTest
 from .seasonality import OCSBTest
 from .stationarity import ADFTest

--- a/pmdarima/arima/seasonality.py
+++ b/pmdarima/arima/seasonality.py
@@ -2,9 +2,7 @@
 #
 # Author: Taylor Smith <taylor.smith@alkaline-ml.com>
 #
-# Tests for seasonal differencing terms
-
-from __future__ import absolute_import, division
+# Tests for seasonal differencing terms, and seasonal decomposition
 
 from collections import namedtuple
 
@@ -59,18 +57,19 @@ def decompose(x, type_, m, filter_=None):
     Returns
     -------
     decomposed_tuple : namedtuple
-        A named tuple with `x`, `trend`, `seasonal`, and `random` components
-        where `x` is the input signal, `trend` is the overall trend, `seasonal`
-        is the seasonal component, and `random` is the noisy component. The
-        input signal `x` can be mostly reconstructed by the other three
-        components with a number of points missing equal to `f`.
+        A named tuple with ``x``, ``trend``, ``seasonal``, and ``random``
+        components where ``x`` is the input signal, ``trend`` is the overall
+        trend, ``seasonal`` is the seasonal component, and `random` is the
+        noisy component. The input signal ``x`` can be mostly reconstructed by
+        the other three components with a number of points missing equal to
+        ``m``.
 
     Notes
     -----
     This function is generally used in conjunction with
     :func:`pmdarima.utils.visualization.decomposed_plot`,
     which plots the decomposed components. Also there are two example notebooks
-    within the `examples` folder which mirror existing R examples.
+    within the ``examples`` folder which mirror existing R examples.
 
      References
     ----------
@@ -78,9 +77,7 @@ def decompose(x, type_, m, filter_=None):
            https://anomaly.io/seasonal-trend-decomposition-in-r/index.html
 
     .. [2] R documentation for decompose:
-           https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/decompose
-
-
+           https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/decompose  # noqa: E501
     """
 
     multiplicative = "multiplicative"
@@ -123,11 +120,11 @@ def decompose(x, type_, m, filter_=None):
     detrend = _decomposer_helper(x[sma_xs], trend)
 
     # Determine the seasonal effect of the signal
-    m = np.reshape(detrend, (int(detrend.shape[0] / m), m))
-    seasonal = np.nanmean(m, axis=0).tolist()
+    m_arr = np.reshape(detrend, (int(detrend.shape[0] / m), m))
+    seasonal = np.nanmean(m_arr, axis=0).tolist()
     seasonal = np.array(seasonal[half_m:] + seasonal[:half_m])
     temp = seasonal
-    for i in range(m.shape[0]):
+    for i in range(m_arr.shape[0]):
         seasonal = np.concatenate((seasonal, temp))
 
     # We buffer the trend component so that it is the same length as the other

--- a/pmdarima/arima/tests/test_approx.py
+++ b/pmdarima/arima/tests/test_approx.py
@@ -1,7 +1,5 @@
 # Test the approximation function
 
-from __future__ import absolute_import
-
 from pmdarima.arima.approx import approx, _regularize
 from pmdarima.utils.array import c
 from pmdarima.arima.stationarity import ADFTest

--- a/pmdarima/arima/tests/test_arima_diagnostics.py
+++ b/pmdarima/arima/tests/test_arima_diagnostics.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-
 from pmdarima.datasets import load_lynx
 from pmdarima.arima import ARIMA
 

--- a/pmdarima/arima/tests/test_c_arima.py
+++ b/pmdarima/arima/tests/test_c_arima.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-
 from pmdarima.arima._arima import C_is_not_finite
 
 import numpy as np

--- a/pmdarima/arima/tests/test_seasonality.py
+++ b/pmdarima/arima/tests/test_seasonality.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # seasonality tests
 
-from __future__ import absolute_import
-
 from pmdarima.arima.seasonality import CHTest, decompose, OCSBTest
 from pmdarima.arima.utils import nsdiffs
 from pmdarima.compat.pytest import pytest_error_str

--- a/pmdarima/arima/tests/test_stationarity.py
+++ b/pmdarima/arima/tests/test_stationarity.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # stationarity tests
 
-from __future__ import absolute_import
-
 from pmdarima.arima.stationarity import ADFTest, PPTest, KPSSTest
 from pmdarima.arima.utils import ndiffs
 from pmdarima.utils.array import diff

--- a/pmdarima/datasets/tests/__init__.py
+++ b/pmdarima/datasets/tests/__init__.py
@@ -1,3 +1,0 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import

--- a/pmdarima/setup.py
+++ b/pmdarima/setup.py
@@ -4,9 +4,8 @@
 #
 # Setup for submodules of pmdarima
 
-from __future__ import absolute_import
-
 import os
+import sys
 
 from pmdarima._build_utils import maybe_cythonize_extensions
 
@@ -35,13 +34,19 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('model_selection')
     config.add_subpackage('model_selection/tests')
 
-    # the following packages have cython, so they have to be build
-    # after the above.
+    # the following packages have cython, and their own setup.py files.
     config.add_subpackage('arima')
     config.add_subpackage('preprocessing')
     config.add_subpackage('utils')
 
-    # do cythonization
+    # add test directory
+    config.add_subpackage('tests')
+
+    # TODO: scikit skips cythonizing on sdist release. should we?
+    # Do cythonization, but only if this is not a release tarball, since the
+    # C/C++ files are not necessarily forward compatible with future versions
+    # of python.
+    # if 'sdist' not in sys.argv:
     maybe_cythonize_extensions(top_path, config)
 
     return config


### PR DESCRIPTION
General clean up including, but not limited to:

* Adding link in API ref for `pm.decompose`
* Add `decompose` to top-level API so you can just do `pm.decompose`
* Clean out some old, pre-Python3 imports
* Add an `__init__.py` to `model_selection/tests` which *may* have contributed to breaking build-from-source builds