### PR TITLE
[HOTFIX] Hotfix tagged linux deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,10 @@ commands:
       pythonversion:
         type: string
     steps:
-      # Currently handled in Makefile, but if ever removed, need this:
-      # - run:
-      #     name: Create VERSION file
-      #     command: make version
+      # does not use makefile, since will require python>=3.5
+      - run:
+          name: Create VERSION file
+          command: python build_tools/get_tag.py
       - run:
           name: Build wheel file
           command: ./build_tools/circle/build_wheel.sh << parameters.pythonversion >>

--- a/build_tools/circle/build_manylinux_wheel.sh
+++ b/build_tools/circle/build_manylinux_wheel.sh
@@ -17,6 +17,10 @@ ${PIP} install --upgrade numpy
 # NOW we can install requirements
 ${PIP} install -r /io/requirements.txt
 make -C /io/ PYTHON="${PYTHON}"
+
+# Make sure the VERSION file is present for this. For whatever reason, the
+# make -C call removes it
+echo ${PMDARIMA_VERSION} > /io/pmdarima/VERSION
 ${PIP} wheel /io/ -w /io/dist/
 
 # Bundle external shared libraries into the wheels.

--- a/build_tools/circle/build_push_doc.sh
+++ b/build_tools/circle/build_push_doc.sh
@@ -11,6 +11,21 @@ if [[ ! -d pmdarima/__check_build ]]; then
     exit 3
 fi
 
+# The version is retrieved from the CIRCLE_TAG. If there is no version, we just
+# call it 0.0.0, since we won't be pushing anyways (not master and no tag)
+if [[ ! -z ${CIRCLE_TAG} ]]; then
+    # We should have the VERSION file on tags now since 'make documentation'
+    # gets it. If not, we use 0.0.0. There are two cases we ever deploy:
+    #   1. Master (where version is not used, as we use 'develop'
+    #   2. Tags (where version IS defined)
+    echo "On tag"
+    make version
+    version=`cat pmdarima/VERSION`
+else
+    echo "Not on tag, will use version=0.0.0"
+    version="0.0.0"
+fi
+
 # get the running branch
 # branch=$(git symbolic-ref --short HEAD)
 
@@ -120,20 +135,6 @@ else
   # Move the HTML contents into the local dir
   mv html/* ./
   rm -r html/
-
-  # The version is retrieved from the GIT_TAG. If there is no version, we just
-  # call it 0.0.0, since we won't be pushing anyways (not master and no tag)
-  if [[ ! -z ${CIRCLE_TAG} ]]; then
-    # We should have the VERSION file on tags now since 'make documentation' gets
-    # it. If not, we use 0.0.0. There are two cases we ever deploy:
-    #   1. Master (where version is not used, as we use 'develop'
-    #   2. Tags (where version IS defined)
-    echo "On tag, expecting VERSION file to have been created"
-    version=`cat pmdarima/VERSION`
-  else
-    echo "Not on tag, will use 0.0.0"
-    version="0.0.0"
-  fi
 
   echo ${version} > VERSION
   echo "New version: ${version}"

--- a/build_tools/circle/build_push_doc.sh
+++ b/build_tools/circle/build_push_doc.sh
@@ -123,7 +123,7 @@ else
 
   # The version is retrieved from the GIT_TAG. If there is no version, we just
   # call it 0.0.0, since we won't be pushing anyways (not master and no tag)
-  if [[ ! -z ${GIT_TAG} ]]; then
+  if [[ ! -z ${CIRCLE_TAG} ]]; then
     # We should have the VERSION file on tags now since 'make documentation' gets
     # it. If not, we use 0.0.0. There are two cases we ever deploy:
     #   1. Master (where version is not used, as we use 'develop'

--- a/build_tools/circle/build_wheel.sh
+++ b/build_tools/circle/build_wheel.sh
@@ -21,13 +21,16 @@ function build_wheel {
 
     DOCKER_CONTAINER_NAME="wheel_builder"
     ML_IMAGE="quay.io/pypa/manylinux1_${arch}"
+    PMDARIMA_VERSION=`cat ~/pmdarima/pmdarima/VERSION`
 
     docker pull "${ML_IMAGE}"
+    # -v "${_root}":/io \
     docker run \
         --name "${DOCKER_CONTAINER_NAME}" \
-        -v "${_root}":/io \
+        -v `pwd`:/io \
         -e "PYMODULE=pmdarima" \
         -e "PYTHON_VERSION=${ML_PYTHON_VERSION}" \
+        -e "PMDARIMA_VERSION=${PMDARIMA_VERSION}" \
         "${ML_IMAGE}" "/io/build_tools/circle/build_manylinux_wheel.sh"
     sudo docker cp "${DOCKER_CONTAINER_NAME}:/io/dist/." "${_root}/dist/"
     docker rm $(docker ps -a -f status=exited -q)

--- a/build_tools/circle/test_version_tagging.sh
+++ b/build_tools/circle/test_version_tagging.sh
@@ -3,7 +3,7 @@
 set -e
 pip install pathlib
 
-GIT_TAG=0.99.999 python ~/pmdarima/build_tools/get_tag.py
+CIRCLE_TAG=0.99.999 python ~/pmdarima/build_tools/get_tag.py
 
 if [[ ! -f ~/pmdarima/pmdarima/VERSION ]]; then
     echo "Expected VERSION file"

--- a/build_tools/get_tag.py
+++ b/build_tools/get_tag.py
@@ -14,10 +14,10 @@ def get_version_from_tag(tag):
 
 
 # Circle is easy, since they give us the git tag
-if os.getenv('CIRCLECI', False) and os.getenv('GIT_TAG', False):
+if os.getenv('CIRCLECI', False) and os.getenv('CIRCLE_TAG', False):
     print('Tagged commit on Circle CI. Writing to {0}'.format(OUT_FILE))
     with open(OUT_FILE, 'w') as f:
-        tag = get_version_from_tag(os.getenv('GIT_TAG'))
+        tag = get_version_from_tag(os.getenv('CIRCLE_TAG'))
         f.write(tag)
 
 # on Azure Pipelines, we have to look at the build branch, and apply this logic:

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,9 @@ if SETUPTOOLS_COMMANDS.intersection(sys.argv):
     extra_setuptools_args = dict(
         zip_safe=False,  # the package can run out of an .egg file
         include_package_data=True,
+        data_files=[
+            ('pmdarima', ['pmdarima/VERSION']),
+        ],
         # scikit does this:
         # extras_require={
         #     'alldeps': REQUIREMENTS
@@ -246,6 +249,7 @@ def do_setup():
                         DISTNAME=[
                             '*',
                             'pmdarima/*',
+                            'pmdarima/VERSION',
                             'pmdarima/__check_build/*',
                             'pmdarima/_build_utils/*',
                             'pmdarima/arima/*',


### PR DESCRIPTION
The migration to versioning with tags caused a couple problems:

* Even though `sdist` bundled the `VERSION` file, the binary wheels left it out of their MANIFEST.
* `GIT_TAG` may have been deprecated from Circle. We should be using `CIRCLE_TAG`
* There was an order-of-operations error in the doc deployment RE: versioning
* The wheel repair script ignored the version file and would have deployed 0.0.0 versioned binaries, had we not already failed for other reasons.