### PR TITLE
[MRG+2] Sklearn deprecation fixes

### DIFF
--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -547,7 +547,7 @@ class ARIMA(BaseARIMA):
             The confidence intervals for the predictions. Only returned if
             ``return_conf_int`` is True.
         """
-        check_is_fitted(self, 'arima_res_')
+        check_is_fitted(self)
 
         # TODO: remove this, it's a compat check
         if kwargs.pop("typ", None):
@@ -618,7 +618,7 @@ class ARIMA(BaseARIMA):
             The confidence intervals for the forecasts. Only returned if
             ``return_conf_int`` is True.
         """
-        check_is_fitted(self, 'arima_res_')
+        check_is_fitted(self)
         if not isinstance(n_periods, (int, long)):
             raise TypeError("n_periods must be an int or a long")
 
@@ -755,7 +755,7 @@ class ARIMA(BaseARIMA):
         * Internally, this calls ``fit`` again using the OLD model parameters
           as the starting parameters for the new model's MLE computation.
         """
-        check_is_fitted(self, 'arima_res_')
+        check_is_fitted(self)
         model_res = self.arima_res_
 
         # Allow updating with a scalar if the user is just adding a single

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -9,7 +9,7 @@ from __future__ import print_function, absolute_import, division
 
 from sklearn.metrics import mean_absolute_error, mean_squared_error
 from sklearn.utils.metaestimators import if_delegate_has_method
-from sklearn.utils.validation import check_is_fitted, check_array
+from sklearn.utils.validation import check_array
 
 from statsmodels.tsa.base.tsa_model import TimeSeriesModelResults
 from statsmodels import api as sm
@@ -22,6 +22,7 @@ import os
 from ..base import BaseARIMA
 from ..compat.numpy import DTYPE  # DTYPE for arrays
 from ..compat.python import long
+from ..compat.sklearn import get_compatible_check_is_fitted
 from ..compat import statsmodels as sm_compat
 from ..utils import get_callable, if_has_delegate, is_iterable, check_endog, \
     check_exog
@@ -547,7 +548,7 @@ class ARIMA(BaseARIMA):
             The confidence intervals for the predictions. Only returned if
             ``return_conf_int`` is True.
         """
-        check_is_fitted(self)
+        get_compatible_check_is_fitted(self, 'arima_res_')
 
         # TODO: remove this, it's a compat check
         if kwargs.pop("typ", None):
@@ -618,7 +619,7 @@ class ARIMA(BaseARIMA):
             The confidence intervals for the forecasts. Only returned if
             ``return_conf_int`` is True.
         """
-        check_is_fitted(self)
+        get_compatible_check_is_fitted(self, 'arima_res_')
         if not isinstance(n_periods, (int, long)):
             raise TypeError("n_periods must be an int or a long")
 
@@ -755,7 +756,7 @@ class ARIMA(BaseARIMA):
         * Internally, this calls ``fit`` again using the OLD model parameters
           as the starting parameters for the new model's MLE computation.
         """
-        check_is_fitted(self)
+        get_compatible_check_is_fitted(self, 'arima_res_')
         model_res = self.arima_res_
 
         # Allow updating with a scalar if the user is just adding a single

--- a/pmdarima/compat/__init__.py
+++ b/pmdarima/compat/__init__.py
@@ -9,6 +9,7 @@ from .matplotlib import *
 from .pandas import *
 from .python import *
 from .numpy import *
+from .sklearn import *
 from .statsmodels import *
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pmdarima/compat/sklearn.py
+++ b/pmdarima/compat/sklearn.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Author: Charles Drotar <drotarcharles@gmail.com>
+#
+# Patch backend for sklearn
+
+from __future__ import absolute_import
+
+import sklearn
+from sklearn.utils.validation import check_is_fitted
+
+__all__ = [
+    'get_compatible_check_is_fitted'
+]
+
+
+def get_compatible_check_is_fitted(estimator, attributes=None):
+    """Make the ``check_is_fitted`` function compatible across the
+    sklearn 0.21 to 0.22+ boundary.
+
+
+    Parameters
+    ----------
+    estimator : estimator instance,
+        The estimator that will be checked to see if it is fitted.
+
+    attributes : str, optional (default=None)
+        The attributes to be passed into the ``check_is_fitted`` function.
+
+    """
+
+    # Split the version string from sklearn and use that determine how to use
+    # the `sklearn.utils.validation import check_is_fitted` function
+    semantic_version_split = [int(x) for x in sklearn.__version__.split(".")]
+    major_version = semantic_version_split[0]
+    minor_version = semantic_version_split[1]
+
+    # Determine if we should require a value for the attribute field
+    is_no_attribute_needed = False
+    if major_version == 0 and minor_version > 21:
+        is_no_attribute_needed = True
+
+    # If we need to pass in `attributes` but it is not a str type raise error.
+    if not is_no_attribute_needed and not isinstance(attributes, str):
+        raise TypeError("Parameter `attributes` can only accept str type")
+
+    # If we don't need an attribute (i.e. sklearn.__version__ >= 0.22)
+    # We ignore `attributes` to bypass warning
+    if is_no_attribute_needed:
+        return check_is_fitted(estimator=estimator)
+
+    # Otherwise we use the attribute that was passed in regardless of version.
+    return check_is_fitted(estimator=estimator, attributes=attributes)

--- a/pmdarima/compat/sklearn.py
+++ b/pmdarima/compat/sklearn.py
@@ -4,7 +4,7 @@
 #
 # Patch backend for sklearn
 
-from __future__ import absolute_import
+from pkg_resources import parse_version
 
 import sklearn
 from sklearn.utils.validation import check_is_fitted
@@ -29,17 +29,13 @@ def get_compatible_check_is_fitted(estimator, attributes=None):
 
     """
 
-    # Split the version string from sklearn and use that determine how to use
+    # Use the version string from sklearn to determine how to use
     # the `sklearn.utils.validation import check_is_fitted` function
-    semantic_version_split = [int(x) for x in sklearn.__version__.split(".")]
-    major_version = semantic_version_split[0]
-    minor_version = semantic_version_split[1]
-
     # Determine if we should require a value for the attribute field
     is_no_attribute_needed = False
-    if major_version == 0 and minor_version > 21:
+    if parse_version(sklearn.__version__) >= parse_version('0.22.0'):
         is_no_attribute_needed = True
-
+        
     # If we need to pass in `attributes` but it is not a str type raise error.
     if not is_no_attribute_needed and not isinstance(attributes, str):
         raise TypeError("Parameter `attributes` can only accept str type")

--- a/pmdarima/model_selection/_validation.py
+++ b/pmdarima/model_selection/_validation.py
@@ -11,7 +11,7 @@ import time
 from traceback import format_exception_only
 
 from sklearn import base
-from sklearn.metrics import regression as reg
+from sklearn.metrics import mean_absolute_error, mean_squared_error
 from sklearn.utils import indexable, safe_indexing
 
 from ._split import check_cv
@@ -26,8 +26,8 @@ __all__ = [
 
 
 _valid_scoring = {
-    'mean_absolute_error': reg.mean_absolute_error,
-    'mean_squared_error': reg.mean_squared_error,
+    'mean_absolute_error': mean_absolute_error,
+    'mean_squared_error': mean_squared_error,
     'smape': metrics.smape,
 }
 

--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -4,7 +4,6 @@ from itertools import islice
 import warnings
 
 from sklearn.base import BaseEstimator, clone
-from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.metaestimators import if_delegate_has_method
 
 from .base import BaseARIMA
@@ -12,7 +11,7 @@ from .preprocessing.base import BaseTransformer
 from .preprocessing.endog.base import BaseEndogTransformer
 from .preprocessing.exog.base import BaseExogTransformer, BaseExogFeaturizer
 from .utils import check_endog
-from .compat import DTYPE
+from .compat import DTYPE, get_compatible_check_is_fitted
 
 __all__ = ['Pipeline']
 
@@ -213,7 +212,7 @@ class Pipeline(BaseEstimator):
 
     def _pre_predict(self, n_periods, exogenous, **kwargs):
         """Runs transformation steps before predicting on data"""
-        check_is_fitted(self)
+        get_compatible_check_is_fitted(self, "steps_")
 
         # Push the arrays through the transformer stages, but ONLY the exog
         # transformer stages since we don't have a Y...
@@ -446,7 +445,7 @@ class Pipeline(BaseEstimator):
             compound, comprised of the stage name and the argument name
             separated by a "__".
         """
-        check_is_fitted(self)
+        get_compatible_check_is_fitted(self, "steps_")
 
         # Push the arrays through all of the transformer steps that have the
         # appropriate update_and_transform method

--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -213,7 +213,7 @@ class Pipeline(BaseEstimator):
 
     def _pre_predict(self, n_periods, exogenous, **kwargs):
         """Runs transformation steps before predicting on data"""
-        check_is_fitted(self, "steps_")
+        check_is_fitted(self)
 
         # Push the arrays through the transformer stages, but ONLY the exog
         # transformer stages since we don't have a Y...
@@ -446,7 +446,7 @@ class Pipeline(BaseEstimator):
             compound, comprised of the stage name and the argument name
             separated by a "__".
         """
-        check_is_fitted(self, "steps_")
+        check_is_fitted(self)
 
         # Push the arrays through all of the transformer steps that have the
         # appropriate update_and_transform method

--- a/pmdarima/preprocessing/endog/boxcox.py
+++ b/pmdarima/preprocessing/endog/boxcox.py
@@ -103,7 +103,7 @@ class BoxCoxEndogTransformer(BaseEndogTransformer):
         exogenous : array-like or None
             The exog array
         """
-        check_is_fitted(self, "lam1_")
+        check_is_fitted(self)
         lam1 = self.lam1_
         lam2 = self.lam2_
 
@@ -150,7 +150,7 @@ class BoxCoxEndogTransformer(BaseEndogTransformer):
         exogenous : array-like or None
             The inverse-transformed exogenous array
         """
-        check_is_fitted(self, "lam1_")
+        check_is_fitted(self)
         lam1 = self.lam1_
         lam2 = self.lam2_
 

--- a/pmdarima/preprocessing/endog/boxcox.py
+++ b/pmdarima/preprocessing/endog/boxcox.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from scipy import stats
-from sklearn.utils.validation import check_is_fitted
 
 import numpy as np
 import warnings
+
+from pmdarima.compat import get_compatible_check_is_fitted
 
 from .base import BaseEndogTransformer
 
@@ -103,7 +104,7 @@ class BoxCoxEndogTransformer(BaseEndogTransformer):
         exogenous : array-like or None
             The exog array
         """
-        check_is_fitted(self)
+        get_compatible_check_is_fitted(self, "lam1_")
         lam1 = self.lam1_
         lam2 = self.lam2_
 
@@ -150,7 +151,7 @@ class BoxCoxEndogTransformer(BaseEndogTransformer):
         exogenous : array-like or None
             The inverse-transformed exogenous array
         """
-        check_is_fitted(self)
+        get_compatible_check_is_fitted(self, "lam1_")
         lam1 = self.lam1_
         lam2 = self.lam2_
 

--- a/pmdarima/preprocessing/exog/fourier.py
+++ b/pmdarima/preprocessing/exog/fourier.py
@@ -187,7 +187,7 @@ class FourierFeaturizer(BaseExogFeaturizer, UpdatableMixin):
             ``n_periods`` corresponds to the number of samples that will be
             returned.
         """
-        check_is_fitted(self, "p_")
+        check_is_fitted(self)
         _, exog = self._check_y_exog(y, exogenous, null_allowed=True)
 
         if n_periods and exog is not None:
@@ -226,7 +226,7 @@ class FourierFeaturizer(BaseExogFeaturizer, UpdatableMixin):
         **kwargs : keyword args
             Keyword arguments required by the transform function.
         """
-        check_is_fitted(self, "p_")
+        check_is_fitted(self)
 
         self._check_endog(y)
         _, Xt = self.transform(y, exogenous, n_periods=len(y), **kwargs)

--- a/pmdarima/preprocessing/exog/fourier.py
+++ b/pmdarima/preprocessing/exog/fourier.py
@@ -2,10 +2,10 @@
 
 import numpy as np
 
-from sklearn.utils.validation import check_is_fitted
 
 from .base import BaseExogFeaturizer
 from ..base import UpdatableMixin
+from ...compat import get_compatible_check_is_fitted
 from ._fourier import C_fourier_terms
 
 __all__ = ['FourierFeaturizer']
@@ -187,7 +187,7 @@ class FourierFeaturizer(BaseExogFeaturizer, UpdatableMixin):
             ``n_periods`` corresponds to the number of samples that will be
             returned.
         """
-        check_is_fitted(self)
+        get_compatible_check_is_fitted(self, "p_")
         _, exog = self._check_y_exog(y, exogenous, null_allowed=True)
 
         if n_periods and exog is not None:
@@ -226,7 +226,7 @@ class FourierFeaturizer(BaseExogFeaturizer, UpdatableMixin):
         **kwargs : keyword args
             Keyword arguments required by the transform function.
         """
-        check_is_fitted(self)
+        get_compatible_check_is_fitted(self, "p_")
 
         self._check_endog(y)
         _, Xt = self.transform(y, exogenous, n_periods=len(y), **kwargs)


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Addresses the follow deprecation warnings from [issue#252](https://github.com/alkaline-ml/pmdarima/issues/252):

`0.23`

- [x] `check_is_fitted`
  - `/Users/runner/hostedtoolcache/Python/3.6.9/x64/lib/python3.6/site-packages/sklearn/utils/validation.py:933: FutureWarning: Passing attributes to check_is_fitted is deprecated and will be removed in 0.23.`

`0.24`

- [x] sklearn.metrics.regression
  - `FutureWarning: The sklearn.metrics.regression module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.metrics. Anything that cannot be imported from sklearn.metrics is now part of the private API.`


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)expected)

# How Has This Been Tested?

- [x] Validate that warnings dropped
- [x] Existing tests passed

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
