### PR TITLE
[MRG+1] Show versions

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -119,19 +119,14 @@ following rules before submitting:
    descriptive text using ``!<PULL REQUEST NUMBER>``
 
 -  Please include your operating system type and version number, as well
-   as your Python, scikit-learn, numpy, scipy, pandas and pmdarima versions. This
-   information can be found by running the following code snippet:
+   as your Python, statsmodels, scikit-learn, numpy, scipy, pandas and pmdarima
+   versions. This information can be found by running the following code
+   snippet:
 
   .. code-block:: python
 
-      import platform; print(platform.platform())
-      import sys; print("Python", sys.version)
-      import numpy; print("NumPy", numpy.__version__)
-      import scipy; print("SciPy", scipy.__version__)
-      import sklearn; print("Scikit-Learn", sklearn.__version__)
-      import pandas; print("Pandas", pandas.__version__)
-      import statsmodels; print("Statsmodels", statsmodels.__version__)
-      import pmdarima; print("pmdarima", pmdarima.__version__)
+      import pmdarima as pm;
+      pm.show_versions()
 
 - Please don't be a **lazy issue-filer!** Submitting a screen shot of an Excel document,
   or poorly-formatted/incomplete code makes the maintainers' lives difficult. Please include your data inline

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,7 +47,7 @@ Other versions
 
 Documentation for other release versions of ``pmdarima``:
 
-* `v1.5.0 <http://alkaline-ml.com/pmdarima/1.5.0>`_
+* `v1.5.1 <http://alkaline-ml.com/pmdarima/1.5.1>`_
 * `v1.4.0 <http://alkaline-ml.com/pmdarima/1.4.0>`_
 * `v1.3.0 <http://alkaline-ml.com/pmdarima/1.3.0>`_
 * `v1.2.0 <http://alkaline-ml.com/pmdarima/1.2.0>`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,7 +8,15 @@ As new releases of pmdarima are pushed out, the following list (introduced in
 v0.8.1) will document the latest features.
 
 
-`v1.5.0 <http://alkaline-ml.com/pmdarima/1.5.0/>`_
+`v1.5.2 <http://alkaline-ml.com/pmdarima/1.5.2/>`_
+--------------------------------------------------
+
+* Added ``pmdarima.show_versions`` as a utility for issue filing
+
+* Fixed deprecation for ``check_is_fitted`` in newer versions of scikit-learn
+
+
+`v1.5.1 <http://alkaline-ml.com/pmdarima/1.5.1/>`_
 --------------------------------------------------
 
 * No longer use statsmodels' ``ARIMA`` or ``ARMA`` class under the hood; only use

--- a/examples/example_simple_fit.py
+++ b/examples/example_simple_fit.py
@@ -25,8 +25,8 @@ data = pm.datasets.load_wineind()
 train, test = data[:150], data[150:]
 
 # Fit a simple auto_arima model
-arima = pm.auto_arima(train, error_action='ignore', trace=1,
-                      suppress_warnings=True,
+arima = pm.auto_arima(train, error_action='ignore', trace=True,
+                      suppress_warnings=True, maxiter=10,
                       seasonal=True, m=12)
 
 # #############################################################################

--- a/pmdarima/__init__.py
+++ b/pmdarima/__init__.py
@@ -48,6 +48,7 @@ else:
     # Stuff we want at top-level
     from .arima import auto_arima, ARIMA, AutoARIMA, StepwiseContext, decompose
     from .utils import acf, autocorr_plot, c, pacf, plot_acf, plot_pacf
+    from .utils._show_versions import show_versions
 
     # Need these namespaces at the top so they can be used like:
     # pm.datasets.load_wineind()
@@ -74,6 +75,7 @@ else:
         'pacf',
         'plot_acf',
         'plot_pacf',
+        'show_versions',
         'StepwiseContext',
     ]
 

--- a/pmdarima/utils/_show_versions.py
+++ b/pmdarima/utils/_show_versions.py
@@ -10,6 +10,19 @@ import platform
 import sys
 import importlib
 
+_pmdarima_deps = (
+    "pip",
+    "setuptools",
+    "sklearn",
+    "statsmodels",
+    "numpy",
+    "scipy",
+    "Cython",
+    "pandas",
+    "joblib",
+    "pmdarima",
+)
+
 
 def _get_sys_info():
     """System information
@@ -31,7 +44,7 @@ def _get_sys_info():
     return dict(blob)
 
 
-def _get_deps_info():
+def _get_deps_info(deps=_pmdarima_deps):
     """Overview of the installed version of main dependencies
 
     Returns
@@ -39,18 +52,6 @@ def _get_deps_info():
     deps_info: dict
         version information on relevant Python libraries
     """
-    deps = [
-        "pip",
-        "setuptools",
-        "sklearn",
-        "statsmodels",
-        "numpy",
-        "scipy",
-        "Cython",
-        "pandas",
-        "joblib",
-    ]
-
     def get_version(module):
         return module.__version__
 

--- a/pmdarima/utils/_show_versions.py
+++ b/pmdarima/utils/_show_versions.py
@@ -1,0 +1,84 @@
+"""
+Utility methods to print system info for debugging
+
+adapted from ``pandas.show_versions``
+adapted from ``sklearn.show_versions``
+"""
+# License: BSD 3 clause
+
+import platform
+import sys
+import importlib
+
+
+def _get_sys_info():
+    """System information
+
+    Return
+    ------
+    sys_info : dict
+        system and Python version information
+
+    """
+    python = sys.version.replace('\n', ' ')
+
+    blob = [
+        ("python", python),
+        ('executable', sys.executable),
+        ("machine", platform.platform()),
+    ]
+
+    return dict(blob)
+
+
+def _get_deps_info():
+    """Overview of the installed version of main dependencies
+
+    Returns
+    -------
+    deps_info: dict
+        version information on relevant Python libraries
+    """
+    deps = [
+        "pip",
+        "setuptools",
+        "sklearn",
+        "statsmodels",
+        "numpy",
+        "scipy",
+        "Cython",
+        "pandas",
+        "joblib",
+    ]
+
+    def get_version(module):
+        return module.__version__
+
+    deps_info = {}
+
+    for modname in deps:
+        try:
+            if modname in sys.modules:
+                mod = sys.modules[modname]
+            else:
+                mod = importlib.import_module(modname)
+            ver = get_version(mod)
+            deps_info[modname] = ver
+        except ImportError:
+            deps_info[modname] = None
+
+    return deps_info
+
+
+def show_versions():
+    """Print useful debugging information"""
+    sys_info = _get_sys_info()
+    deps_info = _get_deps_info()
+
+    print('\nSystem:')
+    for k, stat in sys_info.items():
+        print("{k:>10}: {stat}".format(k=k, stat=stat))
+
+    print('\nPython dependencies:')
+    for k, stat in deps_info.items():
+        print("{k:>10}: {stat}".format(k=k, stat=stat))

--- a/pmdarima/utils/tests/test_show_versions.py
+++ b/pmdarima/utils/tests/test_show_versions.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import pmdarima as pm
+from pmdarima.utils._show_versions import _get_deps_info
 
 
 # Just show it doesn't blow up...
 def test_show_versions():
     pm.show_versions()
+
+
+def test_show_versions_when_not_present():
+    deps = ['big-ol-fake-pkg']
+    assert _get_deps_info(deps=deps)['big-ol-fake-pkg'] is None

--- a/pmdarima/utils/tests/test_show_versions.py
+++ b/pmdarima/utils/tests/test_show_versions.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+import pmdarima as pm
+
+
+# Just show it doesn't blow up...
+def test_show_versions():
+    pm.show_versions()


### PR DESCRIPTION
This adapts scikit-learn's `show_versions` for our use so that issue-filers can more easily run, e.g.,:

```
>>> import pmdarima as pm
>>> pm.show_versions()

System:
    python: 3.6.7 |Anaconda, Inc.| (default, Oct 23 2018, 14:01:38)  [GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]
executable: /anaconda3/envs/pmdenv/bin/python
   machine: Darwin-18.6.0-x86_64-i386-64bit

Python dependencies:
       pip: 10.0.1
setuptools: 40.5.0
   sklearn: 0.21.3
statsmodels: 0.10.0
     numpy: 1.17.3
     scipy: 1.3.1
    Cython: 0.29
    pandas: 0.25.2
    joblib: 0.13.2
  pmdarima: 1.5.1
```