### PR TITLE
[MRG+1] Fix max_order bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ coverage-dependencies:
 	$(PYTHON) -m pip install coverage pytest-cov codecov
 
 test-lint: test-requirements
-	$(PYTHON) -m flake8 pmdarima --filename='*.py' --ignore E803,F401,F403,W293,W504
+	$(PYTHON) -m flake8 pmdarima --filename='*.py' --ignore F401,F403,W293,W504
 
 test-unit: test-requirements coverage-dependencies
 	$(PYTHON) -m pytest -v --durations=20 --cov-config .coveragerc --cov pmdarima -p no:logging --benchmark-skip

--- a/doc/usecases/sun-spots.rst
+++ b/doc/usecases/sun-spots.rst
@@ -187,8 +187,7 @@ Transforming our data
 
 Since we expect our model to perform better over more normal data, let's experiment with log transformations and
 the `Box-Cox transformation <https://en.wikipedia.org/wiki/Power_transform#Box–Cox_transformation>`_,
-each of which is provided as an endogenous transformer in the Pmdarima package. When ``.fit()`` is called,
-it will learn the transformation parameters:
+each of which is provided as an endogenous transformer in the Pmdarima package.
 
 .. code-block:: python
 
@@ -204,7 +203,8 @@ it will learn the transformation parameters:
 
 
 Hmm... The log transformation didn't seem to help too much. In fact, it seems like it just
-shifted the skew to the other tail.
+shifted the skew to the other tail. Let's try the Box-Cox transformation. When ``.fit()`` is called,
+it will learn the lambda transformation parameter:
 
 
 .. code-block:: python

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,10 @@ v0.8.1) will document the latest features.
 
 * Fix bug where 1.5.1 documentation was labeled version "0.0.0".
 
+* Fix bug reported in `#272 <https://github.com/alkaline-ml/pmdarima/issues/272>`_, where
+  the new default value of ``max_order`` can cause a ``ValueError`` even in default cases
+  when ``stepwise=False``.
+
 
 `v1.5.1 <http://alkaline-ml.com/pmdarima/1.5.1/>`_
 --------------------------------------------------

--- a/pmdarima/arima/_doc.py
+++ b/pmdarima/arima/_doc.py
@@ -253,8 +253,8 @@ _AUTO_ARIMA_DOCSTR = \
     References
     ----------
     .. [1] https://wikipedia.org/wiki/Autoregressive_integrated_moving_average
-    .. [2] R's auto-arima source code: http://bit.ly/2gOh5z2
-    .. [3] R's auto-arima documentation: http://bit.ly/2wbBvUN
+    .. [2] R's auto-arima source code: https://github.com/robjhyndman/forecast/blob/master/R/arima.R  # noqa
+    .. [3] R's auto-arima documentation: https://www.rdocumentation.org/packages/forecast  # noqa
     """
 
 _Y_DOCSTR = """

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -489,29 +489,6 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         if max_Q > 0:
             max_q = min(max_q, m - 1)
 
-    # generate the set of (p, q, P, Q) FIRST, since it is contingent
-    # on whether or not the user is interested in a seasonal ARIMA result.
-    # This will reduce the search space for non-seasonal ARIMA models.
-    # loop p, q. Make sure to loop at +1 interval,
-    # since max_{p|q} is inclusive.
-    if seasonal:
-        gen = (
-            ((p, d, q), (P, D, Q, m))
-            for p in range(start_p, max_p + 1)
-            for q in range(start_q, max_q + 1)
-            for P in range(start_P, max_P + 1)
-            for Q in range(start_Q, max_Q + 1)
-            if p + q + P + Q <= max_order
-        )
-    else:
-        # otherwise it's not seasonal, and we don't need the seasonal pieces
-        gen = (
-            ((p, d, q), (0, 0, 0, 0))
-            for p in range(start_p, max_p + 1)
-            for q in range(start_q, max_q + 1)
-            if p + q <= max_order
-        )
-
     if not stepwise:
 
         # validate max_order
@@ -521,13 +498,32 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
             raise ValueError('max_order must be None or a positive '
                              'integer (>= 0)')
 
-        # alternatively, if the start_p and start_q supercede
-        # the max order, that's a failable offense...
-        if (not seasonal and start_p + start_q > max_order) or \
-                (seasonal and
-                 start_P + start_p + start_Q + start_q > max_order):
-            raise ValueError('If max_order is prescribed, it must '
-                             'exceed sum of starting orders')
+        # NOTE: pre-1.5.2, we started at start_p, start_q, etc. However, when
+        # using stepwise=FALSE in R, hyndman starts at 0. He only uses start_*
+        # when stepwise=TRUE.
+
+        # generate the set of (p, q, P, Q) FIRST, since it is contingent
+        # on whether or not the user is interested in a seasonal ARIMA result.
+        # This will reduce the search space for non-seasonal ARIMA models.
+        # loop p, q. Make sure to loop at +1 interval,
+        # since max_{p|q} is inclusive.
+        if seasonal:
+            gen = (
+                ((p, d, q), (P, D, Q, m))
+                for p in range(0, max_p + 1)
+                for q in range(0, max_q + 1)
+                for P in range(0, max_P + 1)
+                for Q in range(0, max_Q + 1)
+                if p + q + P + Q <= max_order
+            )
+        else:
+            # otherwise it's not seasonal and we don't need the seasonal pieces
+            gen = (
+                ((p, d, q), (0, 0, 0, 0))
+                for p in range(0, max_p + 1)
+                for q in range(0, max_q + 1)
+                if p + q <= max_order
+            )
 
         # if we are fitting a random search rather than an exhaustive one, we
         # will scramble up the generator (as a list) and only fit n_iter ARIMAs

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -463,20 +463,6 @@ def test_the_r_src():
         pytest.param(abc, {'D': -1}),
         pytest.param(abc, {'information_criterion': 'bad-value'}),
         pytest.param(abc, {'m': 0}),
-
-        # show that for starting values > max_order, we'll get an error
-        pytest.param(abc, {'start_p': 5,
-                           'start_q': 5,
-                           'seasonal': False,
-                           'max_order': 3,
-                           'stepwise': False}),
-        pytest.param(abc, {'start_p': 5,
-                           'start_q': 5,
-                           'start_P': 4,
-                           'start_Q': 3,
-                           'seasonal': True,
-                           'max_order': 3,
-                           'stepwise': False}),
     ]
 )
 def test_value_errors(endog, kwargs):

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -470,6 +470,29 @@ def test_value_errors(endog, kwargs):
         auto_arima(endog, **kwargs)
 
 
+@pytest.mark.parametrize(
+    'endog, max_order, kwargs', [
+        # show that for starting values > max_order, we can still get a fit
+        pytest.param(abc, 3, {'start_p': 5,
+                              'start_q': 5,
+                              'seasonal': False,
+                              'stepwise': False}),
+
+        pytest.param(abc, 3, {'start_p': 5,
+                              'start_q': 5,
+                              'start_P': 2,
+                              'start_Q': 2,
+                              'seasonal': True,
+                              'stepwise': False}),
+    ]
+)
+def test_valid_max_order_edges(endog, max_order, kwargs):
+    fit = auto_arima(endog, max_order=max_order, **kwargs)
+    order = fit.order
+    ssnal = fit.seasonal_order
+    assert (sum(order) + sum(ssnal[:3])) <= max_order
+
+
 def test_many_orders():
     lam = 0.5
     lynx_bc = ((lynx ** lam) - 1) / lam


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Fixes #272. Hyndman does not use `start_p`, `start_q`, etc., when `stepwise=False`. This aligns `auto_arima` to be in parity, and removes the `ValueError` when an order exceeds `max_order`, simply omitting that fit.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change

# How Has This Been Tested?

Removes two tests that are now irrelevant, and all remaining tests pass.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
