### PR TITLE
[MRG+2] Back out threading.local in favor of global stepwise context

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,10 @@ v0.8.1) will document the latest features.
 
 * Fix bug where 1.5.1 documentation was labeled version "0.0.0".
 
+* Fix bug reported in `#271 <https://github.com/alkaline-ml/pmdarima/issues/271>`_, where
+  the use of ``threading.local`` to store stepwise context information may have broken
+  job schedulers.
+
 * Fix bug reported in `#272 <https://github.com/alkaline-ml/pmdarima/issues/272>`_, where
   the new default value of ``max_order`` can cause a ``ValueError`` even in default cases
   when ``stepwise=False``.

--- a/pmdarima/arima/_context.py
+++ b/pmdarima/arima/_context.py
@@ -3,18 +3,22 @@
 # Author: Krishna Sunkara (kpsunkara)
 #
 # Re-entrant, reusable context manager to store execution context. Introduced
-# in pmdarima 1.5.0 (see #221)
+# in pmdarima 1.5.0 (see #221), redesigned not to use thread locals in #273
+# (see #271 for context).
 
-import threading
 from abc import ABC, abstractmethod
 from enum import Enum
 import collections
 
-# thread local value to store the context info
-_ctx = threading.local()
-_ctx.store = {}
-
 __all__ = ['AbstractContext', 'ContextStore', 'ContextType']
+
+
+class _CtxSingleton:
+    """Singleton class to store context information"""
+    store = {}
+
+
+_ctx = _CtxSingleton()
 
 
 class ContextType(Enum):
@@ -30,9 +34,8 @@ class AbstractContext(ABC):
     """An abstract context manager to store execution context.
 
     A generic, re-entrant, reusable context manager to store
-    execution context in a threading.local instance. Has helper
-    methods to iterate over the context info and provide a
-    string representation of the context info.
+    execution context. Has helper methods to iterate over the context info
+    and provide a string representation of the context info.
     """
     def __init__(self, **kwargs):
         # remove None valued entries,
@@ -93,10 +96,10 @@ class _emptyContext(AbstractContext):
 
 
 class ContextStore:
-    """A class to wrap access to threading.local() context store
+    """A class to wrap access to the global context store
 
-    This class hosts static methods to wrap access to and
-    encapsulate the threading.local() instance
+    This class hosts static methods to wrap access to and encapsulate the
+    singleton content store instance
     """
     @staticmethod
     def get_context(context_type):

--- a/pmdarima/arima/_context.py
+++ b/pmdarima/arima/_context.py
@@ -4,7 +4,7 @@
 #
 # Re-entrant, reusable context manager to store execution context. Introduced
 # in pmdarima 1.5.0 (see #221), redesigned not to use thread locals in #273
-# (see #271 for context).
+# (see #275 for context).
 
 from abc import ABC, abstractmethod
 from enum import Enum

--- a/pmdarima/utils/visualization.py
+++ b/pmdarima/utils/visualization.py
@@ -392,7 +392,7 @@ def tsdisplay(y, lag_max=50, figsize=(8, 6), title=None, bins=25,
 
     # ax2 is simply the histogram
     hist_kwargs = {} if not hist_kwargs else hist_kwargs
-    _ = ax2.hist(y, bins=bins, **hist_kwargs)
+    _ = ax2.hist(y, bins=bins, **hist_kwargs)  # noqa
     ax2.set_title("Frequency")
 
     fig.tight_layout()


### PR DESCRIPTION

# Description

#271 identified an `AttributeError` that can pop up in the stepwise context that seems related to the use of `threading.local` to store the context. This backs out the use of `threading.local` in favor of a global singleton that stores context.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change

# How Has This Been Tested?

I added a new test that spawns several threads and asserts data is accessible across them.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
