### PR TITLE
[MRG+1] Use new pypy image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
   # For testing PyPy rather than CPython
   pypy:
     docker:
-      - image: tgsmith61591/pmdarima-circle-pypy-base:latest
+      - image: alkaline-ml/pmdarima-circle-pypy-base:latest
     working_directory: ~/pmdarima
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
   # For testing PyPy rather than CPython
   pypy:
     docker:
-      - image: alkaline-ml/pmdarima-circle-pypy-base:latest
+      - image: alkalineml/pmdarima-circle-pypy-base:latest
     working_directory: ~/pmdarima
     steps:
       - checkout


### PR DESCRIPTION

# Description

This PR is related to #269 and alkaline-ml/pmdarima-docker#3 -- its purpose is to point to our new pypy docker image instead of the `tgsmith61591` namespace

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] All existing tests pass when pointed to the new docker image

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
