### PR TITLE
[MRG+2] Test deployments

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: '3.6'
           architecture: 'x64'
       - name: Install Requirements
-        run: python -m pip install requests
+        run: python -m pip install -r requirements.txt
       - name: Run Python Script
         run: python etc/downloads_badges.py
         env:

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: '3.6'
           architecture: 'x64'
       - name: Install Requirements
-        run: python -m pip install -r requirements.txt
+        run: python -m pip install requests
       - name: Run Python Script
         run: python etc/downloads_badges.py
         env:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -130,11 +130,11 @@ jobs:
           fi
         shell: bash
 
-      # Use this one for testing: python -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/pmdarima-*
       - name: Deploying to PyPI
         # Only deploy on tags and when VERSION file created
         if: github.event_name == 'tag' && success() && steps.version_check.version_exists == 'true'
         run: |
+          # If the VERSION ends with a letter (beta, rc, etc.), it is considered a test release
           if [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '[a-zA-Z]'$ ]]; then
             python -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/pmdarima-*
           else

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -133,11 +133,15 @@ jobs:
         # Only deploy on tags and when VERSION file created
         if: github.event_name == 'tag' && success() && steps.version_check.version_exists == 'true'
         run: |
-          # If the VERSION ends with a letter (beta, rc, etc.), it is considered a test release
-          if [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '[a-zA-Z]'$ ]]; then
+          # Check our VERSION. Basically, if it contains letters, it is a pre-release. Othewise,
+          # it has to match X.Y or X.Y.Z
+          if [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
             python -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/pmdarima-*
-          else
+          elif [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
             python -m twine upload --skip-existing dist/pmdarima-*
+          else
+            echo 'Malformed tag'
+            exit 1
           fi
         shell: bash
         env:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -134,7 +134,12 @@ jobs:
       - name: Deploying to PyPI
         # Only deploy on tags and when VERSION file created
         if: github.event_name == 'tag' && success() && steps.version_check.version_exists == 'true'
-        run: python -m twine upload --skip-existing dist/pmdarima-*
+        run: |
+          if [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '[a-zA-Z]'$ ]]; then
+            python -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/pmdarima-*
+          else
+            python -m twine upload --skip-existing dist/pmdarima-*
+          fi
         shell: bash
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -136,8 +136,10 @@ jobs:
           # Check our VERSION. Basically, if it contains letters, it is a pre-release. Otherwise,
           # it has to match X.Y or X.Y.Z
           if [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
+            echo 'Uploading to test pypi'
             python -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/pmdarima-*
           elif [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
+            echo 'Uploading to production pypi'
             python -m twine upload --skip-existing dist/pmdarima-*
           else
             echo 'Malformed tag'

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -15,7 +15,6 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     strategy:
-      fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
         python-version: ['3.5', '3.6', '3.7', '3.8']

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -133,7 +133,7 @@ jobs:
         # Only deploy on tags and when VERSION file created
         if: github.event_name == 'tag' && success() && steps.version_check.version_exists == 'true'
         run: |
-          # Check our VERSION. Basically, if it contains letters, it is a pre-release. Othewise,
+          # Check our VERSION. Basically, if it contains letters, it is a pre-release. Otherwise,
           # it has to match X.Y or X.Y.Z
           if [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
             python -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/pmdarima-*

--- a/README.md
+++ b/README.md
@@ -111,13 +111,17 @@ with open('model.pkl', 'rb') as pkl:
 
 ### Availability
 
-`pmdarima` is available on PyPi in pre-built Wheel files for Python 3.5, 3.6 & 3.7 for the following platforms:
+`pmdarima` is available on PyPi in pre-built Wheel files for Python 3.5+ for the following platforms:
 
 * Mac (64-bit)
 * Linux (64-bit manylinux)
 * Windows (32 & 64-bit)
   
-We have plans for the future for adding Conda distributions, as well.  
+It is also available on conda for Python 3.6 and 3.7 for the following platforms:
+
+* Mac (64-bit)
+* Linux (64-bit)
+* Windows (64-bit)
 
 If a wheel doesn't exist for your platform, you can still `pip install` and it
 will build from the source distribution tarball, however you'll need `cython>=0.29`

--- a/build_tools/azure/conda/deploy.yml
+++ b/build_tools/azure/conda/deploy.yml
@@ -16,7 +16,7 @@ steps:
       #
       # --skip means skip existing (can be a little confusing)
       if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
-        # Adding the `test` label means it doesn't who up unless you specifically
+        # Adding the `test` label means it doesn't show up unless you specifically
         # search for packages with the label `test`
         anaconda upload --label test --skip $output_file
       elif [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then

--- a/build_tools/azure/conda/deploy.yml
+++ b/build_tools/azure/conda/deploy.yml
@@ -18,8 +18,10 @@ steps:
       if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
         # Adding the `test` label means it doesn't show up unless you specifically
         # search for packages with the label `test`
+        echo 'Uploading to conda with test label'
         anaconda upload --label test --skip $output_file
       elif [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
+        echo 'Uploading to production conda channel'
         anaconda upload --skip $output_file
       else
         echo 'Malformed tag'

--- a/build_tools/azure/conda/deploy.yml
+++ b/build_tools/azure/conda/deploy.yml
@@ -14,7 +14,7 @@ steps:
       # If the VERSION ends with a letter (beta, rc, etc.), it is considered a test release
       # --skip means skip existing (can be a little confusing)
       if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '[a-zA-Z]'$ ]]; then
-        # Adding the `test` label maeans it doesn't who up unless you specifically
+        # Adding the `test` label means it doesn't who up unless you specifically
         # search for packages with the label `test`
         anaconda upload --label test --skip $output_file
       else

--- a/build_tools/azure/conda/deploy.yml
+++ b/build_tools/azure/conda/deploy.yml
@@ -11,7 +11,7 @@ steps:
       # This looks like it is running `conda build` again, but it just returns the output file
       output_file=$(conda-build --output --python=$(python.version) conda/)
 
-      # Check our VERSION. Basically, if it contains letters, it is a pre-release. Othewise,
+      # Check our VERSION. Basically, if it contains letters, it is a pre-release. Otherwise,
       # it has to match X.Y or X.Y.Z
       #
       # --skip means skip existing (can be a little confusing)

--- a/build_tools/azure/conda/deploy.yml
+++ b/build_tools/azure/conda/deploy.yml
@@ -1,6 +1,6 @@
 steps:
   - bash: |
-      if [ -f $BUILD_SOURCESDIRECTORY/pmdarima/VERSION ]; then
+      if [ -f ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION ]; then
         echo "##vso[task.setvariable variable=VERSION_EXISTS]true"
       else
          echo "##vso[task.setvariable variable=VERSION_EXISTS]false"
@@ -10,8 +10,16 @@ steps:
   - bash: |
       # This looks like it is running `conda build` again, but it just returns the output file
       output_file=$(conda-build --output --python=$(python.version) conda/)
-      # --skip just means skip existing versions
-      anaconda upload --skip $output_file
+
+      # If the VERSION ends with a letter (beta, rc, etc.), it is considered a test release
+      # --skip means skip existing (can be a little confusing)
+      if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '[a-zA-Z]'$ ]]; then
+        # Adding the `test` label maeans it doesn't who up unless you specifically
+        # search for packages with the label `test`
+        anaconda upload --label test --skip $output_file
+      else
+        anaconda upload --skip $output_file
+      fi
     condition: and(succeeded(), eq(variables['VERSION_EXISTS'], 'true'), contains(variables['Build.SourceBranch'], 'refs/tags'))
     displayName: Deploying to conda
     env:

--- a/build_tools/azure/conda/deploy.yml
+++ b/build_tools/azure/conda/deploy.yml
@@ -11,14 +11,19 @@ steps:
       # This looks like it is running `conda build` again, but it just returns the output file
       output_file=$(conda-build --output --python=$(python.version) conda/)
 
-      # If the VERSION ends with a letter (beta, rc, etc.), it is considered a test release
+      # Check our VERSION. Basically, if it contains letters, it is a pre-release. Othewise,
+      # it has to match X.Y or X.Y.Z
+      #
       # --skip means skip existing (can be a little confusing)
-      if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '[a-zA-Z]'$ ]]; then
+      if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
         # Adding the `test` label means it doesn't who up unless you specifically
         # search for packages with the label `test`
         anaconda upload --label test --skip $output_file
-      else
+      elif [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
         anaconda upload --skip $output_file
+      else
+        echo 'Malformed tag'
+        exit 1
       fi
     condition: and(succeeded(), eq(variables['VERSION_EXISTS'], 'true'), contains(variables['Build.SourceBranch'], 'refs/tags'))
     displayName: Deploying to conda

--- a/build_tools/circle/build_push_doc.sh
+++ b/build_tools/circle/build_push_doc.sh
@@ -160,7 +160,7 @@ ls -la
 # Finally, deploy the branch, but if it's a pull request or tag, don't!!
 if [[ ! -z ${CIRCLE_PULL_REQUEST} ]]; then
   echo "Will not deploy doc on pull request (${CIRCLE_PULL_REQUEST})"
-elif [[ ${CIRCLE_BRANCH} == "master" || (! -z ${CIRCLE_TAG} && ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$')]]; then
+elif [[ ${CIRCLE_BRANCH} == "master" || (! -z ${CIRCLE_TAG} && ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$') ]]; then
   echo "Deploying documentation"
   deploy
 else

--- a/build_tools/circle/build_push_doc.sh
+++ b/build_tools/circle/build_push_doc.sh
@@ -13,7 +13,7 @@ fi
 
 # The version is retrieved from the CIRCLE_TAG. If there is no version, we just
 # call it 0.0.0, since we won't be pushing anyways (not master and no tag)
-if [[ ! -z ${CIRCLE_TAG} && ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
+if [[ ! -z ${CIRCLE_TAG} ]]; then
     # We should have the VERSION file on tags now since 'make documentation'
     # gets it. If not, we use 0.0.0. There are two cases we ever deploy:
     #   1. Master (where version is not used, as we use 'develop'
@@ -160,7 +160,7 @@ ls -la
 # Finally, deploy the branch, but if it's a pull request or tag, don't!!
 if [[ ! -z ${CIRCLE_PULL_REQUEST} ]]; then
   echo "Will not deploy doc on pull request (${CIRCLE_PULL_REQUEST})"
-elif [[ ${CIRCLE_BRANCH} == "master" || ! -z ${CIRCLE_TAG} ]]; then
+elif [[ ${CIRCLE_BRANCH} == "master" || (! -z ${CIRCLE_TAG} && ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$')]]; then
   echo "Deploying documentation"
   deploy
 else

--- a/build_tools/circle/build_push_doc.sh
+++ b/build_tools/circle/build_push_doc.sh
@@ -13,7 +13,7 @@ fi
 
 # The version is retrieved from the CIRCLE_TAG. If there is no version, we just
 # call it 0.0.0, since we won't be pushing anyways (not master and no tag)
-if [[ ! -z ${CIRCLE_TAG} ]]; then
+if [[ ! -z ${CIRCLE_TAG} && ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
     # We should have the VERSION file on tags now since 'make documentation'
     # gets it. If not, we use 0.0.0. There are two cases we ever deploy:
     #   1. Master (where version is not used, as we use 'develop'

--- a/build_tools/circle/build_push_doc.sh
+++ b/build_tools/circle/build_push_doc.sh
@@ -160,7 +160,7 @@ ls -la
 # Finally, deploy the branch, but if it's a pull request or tag, don't!!
 if [[ ! -z ${CIRCLE_PULL_REQUEST} ]]; then
   echo "Will not deploy doc on pull request (${CIRCLE_PULL_REQUEST})"
-elif [[ ${CIRCLE_BRANCH} == "master" || (! -z ${CIRCLE_TAG} && ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$') ]]; then
+elif [[ ${CIRCLE_BRANCH} == "master" || ((! -z ${CIRCLE_TAG}) && (${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$')) ]]; then
   echo "Deploying documentation"
   deploy
 else

--- a/build_tools/circle/deploy.sh
+++ b/build_tools/circle/deploy.sh
@@ -9,8 +9,10 @@ pip install twine wheel
 #
 # On CircleCI, we look for the `v` at the beginning of the version, since we are looking at the tag
 if [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
+  echo 'Uploading to test pypi'
   twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/pmdarima-*
 elif [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
+  echo 'Uploading to production pypi'
   twine upload --skip-existing dist/pmdarima-*
 else
   echo 'Malformed tag'

--- a/build_tools/circle/deploy.sh
+++ b/build_tools/circle/deploy.sh
@@ -3,6 +3,7 @@
 set -e -x
 
 pip install twine wheel
+
 # Check our VERSION. Basically, if it contains letters, it is a pre-release. Othewise,
 # it has to match X.Y or X.Y.Z
 #

--- a/build_tools/circle/deploy.sh
+++ b/build_tools/circle/deploy.sh
@@ -3,9 +3,15 @@
 set -e -x
 
 pip install twine wheel
-# If the VERSION ends with a letter (beta, rc, etc.), it is considered a test release
-if [[ $CIRCLE_TAG =~ '[a-zA-Z]'$ ]]; then
+# Check our VERSION. Basically, if it contains letters, it is a pre-release. Othewise,
+# it has to match X.Y or X.Y.Z
+#
+# On CircleCI, we look for the `v` at the beginning of the version, since we are looking at the tag
+if [[ $CIRCLE_TAG =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
   twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/pmdarima-*
-else
+elif [[ $CIRCLE_TAG =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
   twine upload --skip-existing dist/pmdarima-*
+else
+  echo 'Malformed tag'
+  exit 1
 fi

--- a/build_tools/circle/deploy.sh
+++ b/build_tools/circle/deploy.sh
@@ -8,9 +8,9 @@ pip install twine wheel
 # it has to match X.Y or X.Y.Z
 #
 # On CircleCI, we look for the `v` at the beginning of the version, since we are looking at the tag
-if [[ $CIRCLE_TAG =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
+if [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
   twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/pmdarima-*
-elif [[ $CIRCLE_TAG =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
+elif [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
   twine upload --skip-existing dist/pmdarima-*
 else
   echo 'Malformed tag'

--- a/build_tools/circle/deploy.sh
+++ b/build_tools/circle/deploy.sh
@@ -4,7 +4,7 @@ set -e -x
 
 pip install twine wheel
 
-# Check our VERSION. Basically, if it contains letters, it is a pre-release. Othewise,
+# Check our VERSION. Basically, if it contains letters, it is a pre-release. Otherwise,
 # it has to match X.Y or X.Y.Z
 #
 # On CircleCI, we look for the `v` at the beginning of the version, since we are looking at the tag

--- a/build_tools/circle/deploy.sh
+++ b/build_tools/circle/deploy.sh
@@ -3,9 +3,9 @@
 set -e -x
 
 pip install twine wheel
+# If the VERSION ends with a letter (beta, rc, etc.), it is considered a test release
 if [[ $CIRCLE_TAG =~ '[a-zA-Z]'$ ]]; then
   twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/pmdarima-*
 else
   twine upload --skip-existing dist/pmdarima-*
 fi
-# twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/pmdarima-*

--- a/build_tools/circle/deploy.sh
+++ b/build_tools/circle/deploy.sh
@@ -3,5 +3,9 @@
 set -e -x
 
 pip install twine wheel
-twine upload --skip-existing dist/pmdarima-*
+if [[ $CIRCLE_TAG =~ '[a-zA-Z]'$ ]]; then
+  twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/pmdarima-*
+else
+  twine upload --skip-existing dist/pmdarima-*
+fi
 # twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/pmdarima-*


### PR DESCRIPTION

# Description

This change allows us to test our deployment logic by tagging with _almost any_ tag that (contains a letter)  Examples:

- `v1.5.3rc`
- `v1.5.3rc1`
- `v1.5.3test`

If we tag in this way, the CI/CD pipelines will deploy to:

- test.pypi.org (for PyPI releases)
- Our anaconda.org channel with a label of `test` 
  - Adding this label means no one will see it unless they are specifically searching for it ([source](https://docs.anaconda.com/anaconda-cloud/user-guide/tasks/work-with-packages/#uploading-packages))

It also checks to make sure if the version doesn't match the test format, that it matches one of the following before deploying to production:

- `X.Y.Z`
- `X.Y`

I also removed the `fail-fast = False` logic from GitHub Actions, as that is mostly for debugging.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Tested the bash regex logically locally and it works great

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
