### PR TITLE
[MRG+1] Fix "Downloads" Badge

### DIFF
--- a/etc/downloads_badges.py
+++ b/etc/downloads_badges.py
@@ -37,7 +37,7 @@ def millify(n):
     #  - 967123  -> 967k
     #  - 1000123 -> 1M
     #  - 1100123 -> 1.1M
-    final_output = one_decimal if n > 1e6 and not one_decimal.is_integer() else int(final_num)
+    final_output = one_decimal if n > 1e6 and not one_decimal.is_integer() else int(round(final_num, 0))
 
     return f'{final_output}{millnames[millidx]}'
 


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

This PR fixes a bug where we had `1,958,958` downloads, which _should_display as `2M` on the badge. However, without the `round(x, 0)` in there, it was truncating `1.958958M` to `1M`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
millify(1958958)
Out[5]: '2M'
millify(958958)
Out[6]: '959k'
millify(1948958)
Out[7]: '1.9M'
millify(2158958)
Out[8]: '2.2M'
```

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
