### PR TITLE
[MRG+1] Fix deploy doc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,35 +237,35 @@ workflows:
             filters: *test-only-filters
 
         # run on test and tag
-        - pypy:
-            filters: *test-filters
-        - cpython35:
-            filters: *test-filters
-        - cpython36:
-            filters: *test-filters
-        - cpython37:
-            filters: *test-filters
-        - cpython38:
-            filters: *test-filters
+#        - pypy:
+#            filters: *test-filters
+#        - cpython35:
+#            filters: *test-filters
+#        - cpython36:
+#            filters: *test-filters
+#        - cpython37:
+#            filters: *test-filters
+#        - cpython38:
+#            filters: *test-filters
         - build-doc:
             filters: *test-filters
-        - test-linting:
-            filters: *test-filters
-        - regression-testing:
-            filters: *test-filters
-        - test-install-from-sdist:
-            filters: *test-filters
+#        - test-linting:
+#            filters: *test-filters
+#        - regression-testing:
+#            filters: *test-filters
+#        - test-install-from-sdist:
+#            filters: *test-filters
         - testing-passed:
             requires:
-                - pypy
-                - cpython35
-                - cpython36
-                - cpython37
-                - cpython38
+#                - pypy
+#                - cpython35
+#                - cpython36
+#                - cpython37
+#                - cpython38
                 - build-doc
-                - test-linting
-                - regression-testing
-                - test-install-from-sdist
+#                - test-linting
+#                - regression-testing
+#                - test-install-from-sdist
             filters: *test-filters
 
         # All deployment jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
       - checkout
       # Restore the workspace from build-doc
       - attach_workspace:
-          at: doc/_build/html
+          at: doc
       - run: ./build_tools/circle/deploy_doc.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
       - checkout
       # Restore the workspace from build-doc
       - attach_workspace:
-          at: ~/pmdarima
+          at: ~/pmdarima/doc/_build/html
       - run: ./build_tools/circle/deploy_doc.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,9 +114,9 @@ jobs:
       - run: ./build_tools/circle/build_doc.sh
       # This persists doc/_build/html for the deploy step
       - persist_to_workspace:
-          root: ~/pmdarima
+          root: doc
           paths:
-            - doc/_build/html
+            - _build/html
 
   # For testing lint
   test-linting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,8 @@ jobs:
     steps:
       - checkout
       # Restore the workspace from build-doc
+      # Circle is a little confusing -- we only supply the root from the persist step
+      # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
       - attach_workspace:
           at: doc
       - run: ./build_tools/circle/deploy_doc.sh
@@ -237,35 +239,35 @@ workflows:
             filters: *test-only-filters
 
         # run on test and tag
-#        - pypy:
-#            filters: *test-filters
-#        - cpython35:
-#            filters: *test-filters
-#        - cpython36:
-#            filters: *test-filters
-#        - cpython37:
-#            filters: *test-filters
-#        - cpython38:
-#            filters: *test-filters
+        - pypy:
+            filters: *test-filters
+        - cpython35:
+            filters: *test-filters
+        - cpython36:
+            filters: *test-filters
+        - cpython37:
+            filters: *test-filters
+        - cpython38:
+            filters: *test-filters
         - build-doc:
             filters: *test-filters
-#        - test-linting:
-#            filters: *test-filters
-#        - regression-testing:
-#            filters: *test-filters
-#        - test-install-from-sdist:
-#            filters: *test-filters
+        - test-linting:
+            filters: *test-filters
+        - regression-testing:
+            filters: *test-filters
+        - test-install-from-sdist:
+            filters: *test-filters
         - testing-passed:
             requires:
-#                - pypy
-#                - cpython35
-#                - cpython36
-#                - cpython37
-#                - cpython38
+                - pypy
+                - cpython35
+                - cpython36
+                - cpython37
+                - cpython38
                 - build-doc
-#                - test-linting
-#                - regression-testing
-#                - test-install-from-sdist
+                - test-linting
+                - regression-testing
+                - test-install-from-sdist
             filters: *test-filters
 
         # All deployment jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
       - checkout
       # Restore the workspace from build-doc
       - attach_workspace:
-          at: doc/_build/html
+          at: ~/pmdarima
       - run: ./build_tools/circle/deploy_doc.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,9 +114,9 @@ jobs:
       - run: ./build_tools/circle/build_doc.sh
       # This persists doc/_build/html for the deploy step
       - persist_to_workspace:
-          root: doc
+          root: ~/pmdarima
           paths:
-            - _build/html
+            - doc/_build/html
 
   # For testing lint
   test-linting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
       - checkout
       # Restore the workspace from build-doc
       - attach_workspace:
-          at: ~/pmdarima/doc/_build/html
+          at: doc/_build/html
       - run: ./build_tools/circle/deploy_doc.sh
 
 workflows:

--- a/build_tools/circle/deploy_doc.sh
+++ b/build_tools/circle/deploy_doc.sh
@@ -6,8 +6,14 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/get_version.sh"
 
+# TODO: Remove after debugging
+ls
+
 # move the docs to the top-level directory, stash for checkout
 mv doc/_build/html ./
+
+# TODO: Remove after debugging
+ls
 
 # html/ will stay there actually...
 git stash

--- a/build_tools/circle/deploy_doc.sh
+++ b/build_tools/circle/deploy_doc.sh
@@ -6,14 +6,8 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/get_version.sh"
 
-# TODO: Remove after debugging
-ls
-
 # move the docs to the top-level directory, stash for checkout
 mv doc/_build/html ./
-
-# TODO: Remove after debugging
-ls
 
 # html/ will stay there actually...
 git stash

--- a/build_tools/circle/deploy_doc.sh
+++ b/build_tools/circle/deploy_doc.sh
@@ -6,16 +6,8 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/get_version.sh"
 
-# TODO: Remove after debugging
-ls -al
-ls -al doc/_build/html
-
 # move the docs to the top-level directory, stash for checkout
 mv doc/_build/html ./
-
-# TODO: Remove after debugging
-ls -al
-ls -al html
 
 # html/ will stay there actually...
 git stash

--- a/build_tools/circle/deploy_doc.sh
+++ b/build_tools/circle/deploy_doc.sh
@@ -6,8 +6,16 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/get_version.sh"
 
+# TODO: Remove after debugging
+ls -al
+ls -al doc/_build/html
+
 # move the docs to the top-level directory, stash for checkout
 mv doc/_build/html ./
+
+# TODO: Remove after debugging
+ls -al
+ls -al html
 
 # html/ will stay there actually...
 git stash


### PR DESCRIPTION
# Description

This fixes a bug introduced in #287 

According to the [docs](https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs), when we are re-attaching our workspace, we only need to supply the root. Or else it adds extra layers (which is why our docs ended up at alkaline-ml.com/pmdarima/develop/_build/html)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Debugged using `ls`. I `ls`d the `html` directory after renaming and it seems to work.

See [this run](https://app.circleci.com/jobs/github/alkaline-ml/pmdarima/9747/parallel-runs/0/steps/0-103). First `ls` shows the `doc` directory, then the contents of it. The 3rd `ls` shows it has been renamed to `html`, then the contents of it.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
