### PR TITLE
[MRG+1] Pin statsmodels to 0.10.*

### DIFF
--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -4,7 +4,7 @@ scipy>=1.3.2
 cython>=0.29
 scikit-learn>=0.22
 pandas>=0.19
-statsmodels>=0.10.2
+statsmodels~=0.10.2
 patsy
 pytest
 pytest-mpl

--- a/build_tools/doc/doc_requirements.txt
+++ b/build_tools/doc/doc_requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.16
 scipy>=1.3
 scikit-learn>=0.19
 pandas>=0.19
-statsmodels>=0.10.0
+statsmodels~=0.10.0
 sphinx==1.7.2
 sphinx_gallery==0.1.13
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ numpy>=1.17.3
 pandas>=0.19
 scikit-learn>=0.22
 scipy>=1.3.2
-statsmodels>=0.10.2
+statsmodels~=0.10.2
 urllib3


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

[Statsmodels release `0.11.0` this morning](https://pypi.org/project/statsmodels/0.11.0/#description), which appears to be incompatible with our code. For the short term, we are pinning to `0.10.*`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

[CI/CD is passing](https://app.circleci.com/jobs/github/alkaline-ml/pmdarima/9782), when it [wasn't before](https://app.circleci.com/github/alkaline-ml/pmdarima/pipelines/a7dbe670-dc3e-4a03-80a3-c3ac6174d30a/workflows/54d18f82-d410-4de5-8f8c-4771f8fb46f5)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
