### PR TITLE
[MRG+1] Hotfix for 1.5.3 deploy

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -133,18 +133,8 @@ jobs:
         # Only deploy on tags and when VERSION file created
         if: startsWith(github.ref, 'refs/tags') && success() && steps.version_check.version_exists == 'true'
         run: |
-          # Check our VERSION. Basically, if it contains letters, it is a pre-release. Otherwise,
-          # it has to match X.Y or X.Y.Z
-          if [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
-            echo 'Uploading to test pypi'
-            python -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/pmdarima-*
-          elif [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
-            echo 'Uploading to production pypi'
-            python -m twine upload --skip-existing dist/pmdarima-*
-          else
-            echo 'Malformed tag'
-            exit 1
-          fi
+          chmod +x build_tools/github/deploy.sh
+          ./build_tools/github/deploy.sh
         shell: bash
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Deploying to PyPI
         # Only deploy on tags and when VERSION file created
-        if: github.event_name == 'tag' && success() && steps.version_check.version_exists == 'true'
+        if: startsWith(github.ref, 'refs/tags') && success() && steps.version_check.version_exists == 'true'
         run: |
           # Check our VERSION. Basically, if it contains letters, it is a pre-release. Otherwise,
           # it has to match X.Y or X.Y.Z

--- a/build_tools/azure/conda/deploy.sh
+++ b/build_tools/azure/conda/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This looks like it is running `conda build` again, but it just returns the output file
+output_file=$(conda-build --output --python=$(python.version) conda/)
+
+# Check our VERSION. Basically, if it contains letters, it is a pre-release. Otherwise,
+# it has to match X.Y or X.Y.Z
+#
+# --skip means skip existing (can be a little confusing)
+if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ ^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$ ]]; then
+  # Adding the `test` label means it doesn't show up unless you specifically
+  # search for packages with the label `test`
+  echo 'Uploading to conda with test label'
+  anaconda upload --label test --skip $output_file
+elif [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ ^[0-9]+\.[0-9]+\.?[0-9]*$ ]]; then
+  echo 'Uploading to production conda channel'
+  anaconda upload --skip $output_file
+else
+  echo "Malformed tag: $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION)"
+  exit 1
+fi

--- a/build_tools/azure/conda/deploy.yml
+++ b/build_tools/azure/conda/deploy.yml
@@ -9,26 +9,7 @@ steps:
       fi
     displayName: Checking for VERSION file
 
-  - bash: |
-      # This looks like it is running `conda build` again, but it just returns the output file
-      output_file=$(conda-build --output --python=$(python.version) conda/)
-
-      # Check our VERSION. Basically, if it contains letters, it is a pre-release. Otherwise,
-      # it has to match X.Y or X.Y.Z
-      #
-      # --skip means skip existing (can be a little confusing)
-      if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
-        # Adding the `test` label means it doesn't show up unless you specifically
-        # search for packages with the label `test`
-        echo 'Uploading to conda with test label'
-        anaconda upload --label test --skip $output_file
-      elif [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
-        echo 'Uploading to production conda channel'
-        anaconda upload --skip $output_file
-      else
-        echo 'Malformed tag'
-        exit 1
-      fi
+  - bash: deploy.sh
     condition: and(succeeded(), eq(variables['VERSION_EXISTS'], 'true'), contains(variables['Build.SourceBranch'], 'refs/tags'))
     displayName: Deploying to conda
     env:

--- a/build_tools/azure/conda/deploy.yml
+++ b/build_tools/azure/conda/deploy.yml
@@ -1,9 +1,11 @@
 steps:
   - bash: |
       if [ -f ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION ]; then
-        echo "##vso[task.setvariable variable=VERSION_EXISTS]true"
+         echo "##vso[task.setvariable variable=VERSION_EXISTS]true"
+         echo "Version file created"
       else
          echo "##vso[task.setvariable variable=VERSION_EXISTS]false"
+         echo "Version file not created"
       fi
     displayName: Checking for VERSION file
 

--- a/build_tools/azure/conda/windows.yml
+++ b/build_tools/azure/conda/windows.yml
@@ -7,6 +7,7 @@ steps:
 
   - script: make version
     displayName: 'Ensuring VERSION file is created'
+    condition: contains(variables['Build.SourceBranch'], 'refs/tags')
 
   - bash: |
       mkdir conda

--- a/build_tools/azure/conda/windows.yml
+++ b/build_tools/azure/conda/windows.yml
@@ -5,6 +5,9 @@ steps:
   - script: conda install conda-build anaconda-client --yes
     displayName: 'Installing conda-build and anaconda-client'
 
+  - script: make version
+    displayName: 'Ensuring VERSION file is created'
+
   - bash: |
       mkdir conda
       python -m pip install jinja2

--- a/build_tools/azure/test_version_tagging.sh
+++ b/build_tools/azure/test_version_tagging.sh
@@ -5,6 +5,19 @@ pip install pathlib
 
 BUILD_SOURCEBRANCH=refs/tags/v0.99.999 python ${BUILD_SOURCESDIRECTORY}/build_tools/get_tag.py
 
+if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
+  # Adding the `test` label means it doesn't show up unless you specifically
+  # search for packages with the label `test`
+  echo 'Uploading to conda with test label'
+  anaconda upload --label test --skip $output_file
+elif [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
+  echo 'Uploading to production conda channel'
+  anaconda upload --skip $output_file
+else
+  echo "Malformed tag: $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION)"
+  exit 1
+fi
+
 if [[ ! -f ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION ]]; then
     echo "Expected VERSION file"
     exit 4

--- a/build_tools/azure/test_version_tagging.sh
+++ b/build_tools/azure/test_version_tagging.sh
@@ -5,19 +5,6 @@ pip install pathlib
 
 BUILD_SOURCEBRANCH=refs/tags/v0.99.999 python ${BUILD_SOURCESDIRECTORY}/build_tools/get_tag.py
 
-if [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
-  # Adding the `test` label means it doesn't show up unless you specifically
-  # search for packages with the label `test`
-  echo 'Uploading to conda with test label'
-  anaconda upload --label test --skip $output_file
-elif [[ $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION) =~ '^[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
-  echo 'Uploading to production conda channel'
-  anaconda upload --skip $output_file
-else
-  echo "Malformed tag: $(cat ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION)"
-  exit 1
-fi
-
 if [[ ! -f ${BUILD_SOURCESDIRECTORY}/pmdarima/VERSION ]]; then
     echo "Expected VERSION file"
     exit 4

--- a/build_tools/circle/build_wheel.sh
+++ b/build_tools/circle/build_wheel.sh
@@ -9,10 +9,10 @@ function build_wheel {
 
     # https://www.python.org/dev/peps/pep-0513/#ucs-2-vs-ucs-4-builds
     ucs_tag="m"
-    if [ "$ucs_setting" = "ucs4" ]; then
+    if [ "$pyver" = "3.8" ]; then
+      ucs_tag=""
+    elif [ "$ucs_setting" = "ucs4" ]; then
         ucs_tag="${ucs_tag}u"
-    elif [ "$pyver" = "3.8" ]; then
-        ucs_tag=""
     fi
 
     ML_PYTHON_VERSION=$(python -c \

--- a/build_tools/circle/build_wheel.sh
+++ b/build_tools/circle/build_wheel.sh
@@ -11,6 +11,8 @@ function build_wheel {
     ucs_tag="m"
     if [ "$ucs_setting" = "ucs4" ]; then
         ucs_tag="${ucs_tag}u"
+    elif [ "$pyver" = "3.8" ]; then
+        ucs_tag=""
     fi
 
     ML_PYTHON_VERSION=$(python -c \

--- a/build_tools/circle/deploy.sh
+++ b/build_tools/circle/deploy.sh
@@ -8,10 +8,10 @@ pip install twine wheel
 # it has to match X.Y or X.Y.Z
 #
 # On CircleCI, we look for the `v` at the beginning of the version, since we are looking at the tag
-if [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?[a-zA-Z]+[0-9]*$' ]]; then
+if [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*[a-zA-Z]+[0-9]*$' ]]; then
   echo 'Uploading to test pypi'
   twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/pmdarima-*
-elif [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*?$' ]]; then
+elif [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*$' ]]; then
   echo 'Uploading to production pypi'
   twine upload --skip-existing dist/pmdarima-*
 else

--- a/build_tools/circle/deploy.sh
+++ b/build_tools/circle/deploy.sh
@@ -8,10 +8,10 @@ pip install twine wheel
 # it has to match X.Y or X.Y.Z
 #
 # On CircleCI, we look for the `v` at the beginning of the version, since we are looking at the tag
-if [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*[a-zA-Z]+[0-9]*$' ]]; then
+if [[ ${CIRCLE_TAG} =~ ^v?[0-9]+\.[0-9]+\.?[0-9]*[a-zA-Z]+[0-9]*$ ]]; then
   echo 'Uploading to test pypi'
   twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/pmdarima-*
-elif [[ ${CIRCLE_TAG} =~ '^v?[0-9]+\.[0-9]+\.?[0-9]*$' ]]; then
+elif [[ ${CIRCLE_TAG} =~ ^v?[0-9]+\.[0-9]+\.?[0-9]*$ ]]; then
   echo 'Uploading to production pypi'
   twine upload --skip-existing dist/pmdarima-*
 else

--- a/build_tools/github/deploy.sh
+++ b/build_tools/github/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ ^[0-9]+\.[0-9]+\.?[0-9]*[a-zA-Z]+[0-9]*$ ]]; then
+  echo 'Uploading to test pypi'
+  python -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/pmdarima-*
+elif [[ $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION) =~ ^[0-9]+\.[0-9]+\.?[0-9]*$ ]]; then
+  echo 'Uploading to production pypi'
+  python -m twine upload --skip-existing dist/pmdarima-*
+else
+  echo "Malformed tag": $(cat ${GITHUB_WORKSPACE}/pmdarima/VERSION)""
+  exit 1
+fi


### PR DESCRIPTION
# Description

This PR is necessary to address the 4 issues we saw during the v1.5.3 deploy today.

1. Azure Pipelines found a malformed tag when trying to deploy to Conda (only for Mac and Linux)
<img width="857" alt="Screen Shot 2020-02-13 at 7 34 39 PM" src="https://user-images.githubusercontent.com/21350310/74493488-e22f4b80-4e97-11ea-91c9-d3d6e824e6bc.png">  

  * The regex was lazily looking for the last digit: `^[0-9]+\.[0-9]+\.?[0-9]*?$`, so it stopped matching after `1.5.`, leading to a malformed tag. Removing the trailing question mark fixes this. Example:

```bash
set -e
pip install pathlib

BUILD_SOURCEBRANCH=refs/tags/v0.99.999 python ~/Documents/projects/alkaline-ml/pmdarima//build_tools/get_tag.py

if [[ $(cat ~/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION) =~ ^[0-9]+\.[0-9]+\.?[0-9]*[a-zA-Z]+[0-9]*$ ]]; then
  # Adding the `test` label means it doesn't show up unless you specifically
  # search for packages with the label `test`
  echo 'Uploading to conda with test label'
elif [[ $(cat ~/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION) =~ ^[0-9]+\.[0-9]+\.?[0-9]*?$ ]]; then
  echo 'Uploading to production conda channel'
else
  echo "Malformed tag: $(cat ~/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION)"
  exit 1
fi

if [[ ! -f ~/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION ]]; then
    echo "Expected VERSION file"
    exit 4
fi

# Tagged commit on Azure Pipelines. Writing to /Users/asmith/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION
# Malformed tag: 0.99.999
```

Fixed:

```bash
set -e
pip install pathlib

BUILD_SOURCEBRANCH=refs/tags/v0.99.999 python ~/Documents/projects/alkaline-ml/pmdarima//build_tools/get_tag.py

if [[ $(cat ~/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION) =~ ^[0-9]+\.[0-9]+\.?[0-9]*[a-zA-Z]+[0-9]*$ ]]; then
  # Adding the `test` label means it doesn't show up unless you specifically
  # search for packages with the label `test`
  echo 'Uploading to conda with test label'
elif [[ $(cat ~/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION) =~ ^[0-9]+\.[0-9]+\.?[0-9]*$ ]]; then
  echo 'Uploading to production conda channel'
else
  echo "Malformed tag: $(cat ~/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION)"
  exit 1
fi

if [[ ! -f ~/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION ]]; then
    echo "Expected VERSION file"
    exit 4
fi

# Tagged commit on Azure Pipelines. Writing to /Users/asmith/Documents/projects/alkaline-ml/pmdarima/pmdarima/VERSION
# Uploading to production conda channel
```

2) The `VERSION` file was not being created for Windows builds on Azure Pipelines

    * Since we build the Windows dist using `conda-build`, it does not create the VERSION file. For Linux and Mac, we build the wheel first, so it implicitly creates the VERSION file.
    * Solution: We now manually create the VERSION file if it is a tagged commit on Windows

3) Github Actions skipped the deploy step entirely!

    * Apparently `github.event_name` is `push` for tags... So now we use `github.ref` and make sure it starts with `refs/tags`

4) Circle CI failed for Python 3.8

    * Most Python versions on the Red Hat image we use look like this: `cp37-cp37m` or `cp27-cp27mu`. For some reason Python 3.8 looks like this: `cp38-cp38`, so we add a check to fix that _only_ on Python 3.8

<img width="579" alt="Screen Shot 2020-02-13 at 6 37 32 PM" src="https://user-images.githubusercontent.com/21350310/74493905-fc1d5e00-4e98-11ea-99fa-86121eb9ca05.png">

**Miscellaneous**: I also moved the deploy steps on ADO and Github Actions to be their own bash scripts for easier debugging locally

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See above. All checks are passing now

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
