### PR TITLE
[MRG+1] Hotfix take 2

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -126,10 +126,10 @@ jobs:
         run: |
           if [ -f "${GITHUB_WORKSPACE}/pmdarima/VERSION" ]; then
             echo "VERSION file exists"
-            echo "::set-output name=version_exists::true"
+            echo "::set-output name=version_exists::yes"
           else
             echo "VERSION file does not exist"
-            echo "::set-output name=version_exists::false"
+            echo "::set-output name=version_exists::no"
           fi
         shell: bash
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -143,3 +143,9 @@ jobs:
 #        env:
 #          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
 #          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+
+      - name: Check vars
+        run: |
+          echo "${{ github.ref }}"
+          echo "${{ steps.version_check.version_exists }}"
+        shell: bash

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Find the github ref
-        run: echo "${{ github.ref }}
+        run: echo "${{ github.ref }}"
         shell: bash
 
       # Visual Studio 2019 (windows-latest) doesn't include these files for some reason??

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -32,10 +32,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - name: Find the github ref
-        run: echo "${{ github.ref }}"
-        shell: bash
-
       # Visual Studio 2019 (windows-latest) doesn't include these files for some reason??
       # Even stranger, it really only affects Python 3.5, but we run it across all versions for consistency
       # https://social.msdn.microsoft.com/Forums/vstudio/en-US/06675e6d-9a0b-46f5-8de0-10237fab1ece/link-error-lnk1158?forum=vcgeneral
@@ -133,19 +129,13 @@ jobs:
           fi
         shell: bash
 
-#      - name: Deploying to PyPI
-#        # Only deploy on tags and when VERSION file created
-#        if: startsWith(github.ref, 'refs/tags') && success() && steps.version_check.version_exists == 'true'
-#        run: |
-#          chmod +x build_tools/github/deploy.sh
-#          ./build_tools/github/deploy.sh
-#        shell: bash
-#        env:
-#          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-
-      - name: Check vars
+      - name: Deploying to PyPI
+        # Only deploy on tags and when VERSION file created
+        if: startsWith(github.ref, 'refs/tags') && success() && steps.version_check.output.version_exists == 'true'
         run: |
-          echo "${{ github.ref }}"
-          echo "${{ steps.version_check.outputs.version_exists }}"
+          chmod +x build_tools/github/deploy.sh
+          ./build_tools/github/deploy.sh
         shell: bash
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
+      - name: Find the github ref
+        run: echo "${{ github.ref }}
+        shell: bash
+
       # Visual Studio 2019 (windows-latest) doesn't include these files for some reason??
       # Even stranger, it really only affects Python 3.5, but we run it across all versions for consistency
       # https://social.msdn.microsoft.com/Forums/vstudio/en-US/06675e6d-9a0b-46f5-8de0-10237fab1ece/link-error-lnk1158?forum=vcgeneral
@@ -129,13 +133,13 @@ jobs:
           fi
         shell: bash
 
-      - name: Deploying to PyPI
-        # Only deploy on tags and when VERSION file created
-        if: startsWith(github.ref, 'refs/tags') && success() && steps.version_check.version_exists == 'true'
-        run: |
-          chmod +x build_tools/github/deploy.sh
-          ./build_tools/github/deploy.sh
-        shell: bash
-        env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#      - name: Deploying to PyPI
+#        # Only deploy on tags and when VERSION file created
+#        if: startsWith(github.ref, 'refs/tags') && success() && steps.version_check.version_exists == 'true'
+#        run: |
+#          chmod +x build_tools/github/deploy.sh
+#          ./build_tools/github/deploy.sh
+#        shell: bash
+#        env:
+#          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -126,10 +126,10 @@ jobs:
         run: |
           if [ -f "${GITHUB_WORKSPACE}/pmdarima/VERSION" ]; then
             echo "VERSION file exists"
-            echo "::set-output name=version_exists::yes"
+            echo "::set-output name=version_exists::true"
           else
             echo "VERSION file does not exist"
-            echo "::set-output name=version_exists::no"
+            echo "::set-output name=version_exists::false"
           fi
         shell: bash
 
@@ -147,5 +147,5 @@ jobs:
       - name: Check vars
         run: |
           echo "${{ github.ref }}"
-          echo "${{ steps.version_check.version_exists }}"
+          echo "${{ steps.version_check.outputs.version_exists }}"
         shell: bash

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Deploying to PyPI
         # Only deploy on tags and when VERSION file created
-        if: startsWith(github.ref, 'refs/tags') && success() && steps.version_check.output.version_exists == 'true'
+        if: startsWith(github.ref, 'refs/tags') && success() && steps.version_check.outputs.version_exists == 'true'
         run: |
           chmod +x build_tools/github/deploy.sh
           ./build_tools/github/deploy.sh

--- a/build_tools/azure/conda/deploy.yml
+++ b/build_tools/azure/conda/deploy.yml
@@ -9,7 +9,7 @@ steps:
       fi
     displayName: Checking for VERSION file
 
-  - bash: deploy.sh
+  - bash: build_tools/azure/conda/deploy.sh
     condition: and(succeeded(), eq(variables['VERSION_EXISTS'], 'true'), contains(variables['Build.SourceBranch'], 'refs/tags'))
     displayName: Deploying to conda
     env:


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

On our second attempt to deploy 1.5.3, we ran into 2 issues:

1. [`deploy.sh` could not be found be deploy step](https://dev.azure.com/tgsmith61591gh/pmdarima/_build/results?buildId=1649&view=logs&j=094df02d-42f3-5942-83e9-798405c0fd82&t=54a57d57-cd0f-58ed-98ae-8d9fbd8e293d). This is fixed by giving it the full path to the script

2. [The deploy step on GitHub was never even entered](https://github.com/alkaline-ml/pmdarima/runs/446054604?check_suite_focus=true). The check for `steps.version_check.version_exists` needs to be `steps.version_check.outputs.version_exists`

Working here (with a value of `false`):

![Screen Shot 2020-02-14 at 8 34 24 AM](https://user-images.githubusercontent.com/21350310/74540136-de85de00-4f04-11ea-8fcf-e36ddfaef6c8.png)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Github change has been tested on Github

Unable to test the other change until deploy time. However, it is the same syntax as [`azure-pipelines.yml`](https://github.com/alkaline-ml/pmdarima/blob/db4a587195b4739c1d5cd7def0ca98c6153fe1cb/azure-pipelines.yml#L112)

``` yaml
- bash: build_tools/azure/test_version_tagging.sh
```

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
