### PR TITLE
[MRG+2] Added check for out_of_sample_size when information_criterion='oob'

### DIFF
--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -346,12 +346,12 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         raise ValueError('auto_arima not defined for information_criteria=%s. '
                          'Valid information criteria include: %r'
                          % (information_criterion, VALID_CRITERIA))
-        
     
-    #check on information criterion and out_of_sample size 
-    if information_criterion=='oob' and out_of_sample_size==0:
+    # check on information criterion and out_of_sample size
+    if information_criterion == 'oob' and out_of_sample_size == 0:
         information_criterion = 'aic'
-        warnings.warn('information_criterion cannot be \'oob\' with out_of_sample_size = 0. '
+        warnings.warn('information_criterion cannot be \'oob\' with '
+                      'out_of_sample_size = 0. '
                       'Falling back to information criterion = aic.')
 
     # the R code handles this, but I don't think statsmodels

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -346,6 +346,13 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         raise ValueError('auto_arima not defined for information_criteria=%s. '
                          'Valid information criteria include: %r'
                          % (information_criterion, VALID_CRITERIA))
+        
+    
+    #check on information criterion and out_of_sample size 
+    if information_criterion=='oob' and out_of_sample_size==0:
+        information_criterion = 'aic'
+        warnings.warn('information_criterion cannot be \'oob\' with out_of_sample_size = 0. '
+                      'Falling back to information criterion = aic.')
 
     # the R code handles this, but I don't think statsmodels
     # will even fit a model this small...

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -349,6 +349,13 @@ def test_oob_for_issue_29():
                     else:
                         raise
 
+def test_oob_with_zero_out_of_sample_size():
+    with pytest.warns(UserWarning) as uw:
+        auto_arima(y, suppress_warnings=False, information_criterion="oob", out_of_sample_size=0)
+
+    assert uw[0].message.args[0] == "information_criterion cannot be 'oob' " \
+                                    "with out_of_sample_size = 0. Falling " \
+                                    "back to information criterion = aic."
 
 def test_issue_30():
     # From the issue:

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -349,13 +349,16 @@ def test_oob_for_issue_29():
                     else:
                         raise
 
+
 def test_oob_with_zero_out_of_sample_size():
     with pytest.warns(UserWarning) as uw:
-        auto_arima(y, suppress_warnings=False, information_criterion="oob", out_of_sample_size=0)
+        auto_arima(y, suppress_warnings=False, information_criterion="oob",
+                   out_of_sample_size=0)
 
     assert uw[0].message.args[0] == "information_criterion cannot be 'oob' " \
                                     "with out_of_sample_size = 0. Falling " \
                                     "back to information criterion = aic."
+
 
 def test_issue_30():
     # From the issue:


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

When a user specifies information_criterion='oob' but doesn't specify out_of_sample_size while calling auto_arima, no warning is raised. 

Fixes #305 
Raises a warning informing the user about conflicting parameters. Also, switches to default information_criterion='aic'

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- [ ] Test A
```
import numpy as np
import pmdarima as pm
from pmdarima.datasets import load_wineind

# this is a dataset from R
wineind = load_wineind().astype(np.float64)

# fit stepwise auto-ARIMA with information_criterion='oob' but out_of_sample_size not specified
stepwise_fit = pm.auto_arima(wineind, start_p=1, start_q=1,
                             max_p=3, max_q=3, m=12,
                             start_P=0, seasonal=True,
                             d=1, D=1, trace=True,
                             error_action='ignore',  # don't want to know if an order does not work
                             suppress_warnings=True,  # don't want convergence warnings
                             stepwise=True, # set to stepwise
                             information_criterion='oob')  
```

```
auto.py:356: UserWarning: information_criterion cannot be 'oob' with out_of_sample_size = 0. Falling back to information criterion = aic.
  
Performing stepwise search to minimize aic
```
# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
