### PR TITLE
[MRG+2] Replaced keyword argument "normed" to "density" in method pmdarima.arima.ARIMA.plot_diagnostics

### DIFF
--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -21,6 +21,7 @@ from ..base import BaseARIMA
 from ..compat.numpy import DTYPE  # DTYPE for arrays
 from ..compat.sklearn import get_compatible_check_is_fitted, safe_indexing
 from ..compat import statsmodels as sm_compat
+from ..compat import matplotlib as mpl_compat
 from ..compat.matplotlib import mpl_hist_arg
 from ..utils import get_callable, if_has_delegate, is_iterable, check_endog, \
     check_exog
@@ -1197,12 +1198,10 @@ class ARIMA(BaseARIMA):
         ax = fig.add_subplot(222)
         # temporarily disable Deprecation warning, normed -> density
         # hist needs to use `density` in future when minimum matplotlib has it
-        # normed keyword arugment is no longer supported in matplotlib since version 3.2.0
+        # 'normed' argument is no longer supported in matplotlib since
+        # version 3.2.0. New function added for backwards compatibility
         with warnings.catch_warnings(record=True):
-            if mpl_hist_arg:
-                ax.hist(resid_nonmissing, density=True, label='Hist')
-            else:
-                ax.hist(resid_nonmissing, normed=True, label='Hist')
+            ax.hist(resid_nonmissing, label='Hist', **mpl_compat.mpl_hist_arg())
 
         kde = gaussian_kde(resid_nonmissing)
         xlim = (-1.96 * 2, 1.96 * 2)

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -1201,7 +1201,11 @@ class ARIMA(BaseARIMA):
         # 'normed' argument is no longer supported in matplotlib since
         # version 3.2.0. New function added for backwards compatibility
         with warnings.catch_warnings(record=True):
-            ax.hist(resid_nonmissing, label='Hist', **mpl_compat.mpl_hist_arg())
+            ax.hist(
+                resid_nonmissing,
+                label='Hist',
+                **mpl_compat.mpl_hist_arg()
+            )
 
         kde = gaussian_kde(resid_nonmissing)
         xlim = (-1.96 * 2, 1.96 * 2)

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -1196,8 +1196,9 @@ class ARIMA(BaseARIMA):
         ax = fig.add_subplot(222)
         # temporarily disable Deprecation warning, normed -> density
         # hist needs to use `density` in future when minimum matplotlib has it
+        # normed keyword arugment is no longer supported in matplotlib since version 3.2.0
         with warnings.catch_warnings(record=True):
-            ax.hist(resid_nonmissing, normed=True, label='Hist')
+            ax.hist(resid_nonmissing, density=True, label='Hist')
 
         kde = gaussian_kde(resid_nonmissing)
         xlim = (-1.96 * 2, 1.96 * 2)

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -21,6 +21,7 @@ from ..base import BaseARIMA
 from ..compat.numpy import DTYPE  # DTYPE for arrays
 from ..compat.sklearn import get_compatible_check_is_fitted, safe_indexing
 from ..compat import statsmodels as sm_compat
+from ..compat.matplotlib import mpl_hist_arg
 from ..utils import get_callable, if_has_delegate, is_iterable, check_endog, \
     check_exog
 from ..utils.visualization import _get_plt
@@ -1198,7 +1199,10 @@ class ARIMA(BaseARIMA):
         # hist needs to use `density` in future when minimum matplotlib has it
         # normed keyword arugment is no longer supported in matplotlib since version 3.2.0
         with warnings.catch_warnings(record=True):
-            ax.hist(resid_nonmissing, density=True, label='Hist')
+            if mpl_hist_arg:
+                ax.hist(resid_nonmissing, density=True, label='Hist')
+            else:
+                ax.hist(resid_nonmissing, normed=True, label='Hist')
 
         kde = gaussian_kde(resid_nonmissing)
         xlim = (-1.96 * 2, 1.96 * 2)

--- a/pmdarima/compat/matplotlib.py
+++ b/pmdarima/compat/matplotlib.py
@@ -73,5 +73,6 @@ def mpl_hist_arg(value=True):
     """
     import matplotlib
 
-    density_kwarg = 'density' if matplotlib.__version__ >= '2.1.0' else 'normed'
+    density_kwarg = 'density' if matplotlib.__version__ >= '2.1.0'\
+        else 'normed'
     return {density_kwarg: value}

--- a/pmdarima/compat/matplotlib.py
+++ b/pmdarima/compat/matplotlib.py
@@ -8,7 +8,8 @@ import sys
 import os
 
 __all__ = [
-    'get_compatible_pyplot'
+    'get_compatible_pyplot',
+    'mpl_hist_arg'
 ]
 
 
@@ -49,3 +50,22 @@ def get_compatible_pyplot(backend=None, debug=True):
 
     from matplotlib import pyplot as plt
     return plt
+
+
+def mpl_hist_arg():
+    # Function for backwards compatibility with matplotlib.pyplot.hist 'normed' keyword argument
+    # Keyword is deprecated since version 2.1.0 of matplotlib, but was removed completely in version 3.2.0
+    import matplotlib
+    from distutils.version import LooseVersion, StrictVersion
+
+    mpl_version = matplotlib.__version__
+    try:
+        if StrictVersion(mpl_version) >= '2.1.0':
+            return True
+        else:
+            return False
+
+    except ValueError:
+        # matplotlib was not installed from pip or it is a developement version
+        # Assume latest version is installed?
+        return True

--- a/pmdarima/compat/matplotlib.py
+++ b/pmdarima/compat/matplotlib.py
@@ -52,20 +52,26 @@ def get_compatible_pyplot(backend=None, debug=True):
     return plt
 
 
-def mpl_hist_arg():
-    # Function for backwards compatibility with matplotlib.pyplot.hist 'normed' keyword argument
-    # Keyword is deprecated since version 2.1.0 of matplotlib, but was removed completely in version 3.2.0
+def mpl_hist_arg(value=True):
+    """Find the appropriate `density` kwarg for our given matplotlib version.
+
+    This will determine if we should use `normed` or `density`. Additionally,
+    since this is a kwarg, the user can supply a value (True or False) that
+    they would like in the output dictionary.
+
+    Parameters
+    ----------
+    value : bool, optional (default=True)
+        The boolean value of density/normed
+
+    Returns
+    -------
+    density_kwarg : dict
+        A dictionary containing the appropriate density kwarg for the
+        installed  matplotlib version, mapped to the provided or default
+        value
+    """
     import matplotlib
-    from distutils.version import LooseVersion, StrictVersion
 
-    mpl_version = matplotlib.__version__
-    try:
-        if StrictVersion(mpl_version) >= '2.1.0':
-            return True
-        else:
-            return False
-
-    except ValueError:
-        # matplotlib was not installed from pip or it is a developement version
-        # Assume latest version is installed?
-        return True
+    density_kwarg = 'density' if matplotlib.__version__ >= '2.1.0' else 'normed'
+    return {density_kwarg: value}


### PR DESCRIPTION
In response to issue #308.
The "normed" keyword used in method pmdarima.arima.ARIMA.plot_diagnostics (in reference to matplotlib.pyplot.hist) is deprecated.
It has been removed from matplolib since version 3.2.0, and prevented the plot_diagnostics method from working.
It has been replaced with the new supported keyword argument "density".