### PR TITLE
[MRG+1] New error action

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,10 +10,14 @@ coverage:
   status:
     project:
       default:
-        against: parent
-        target: 97%
+        target: 95%
+        informational: true
         branches:
           - master
+
+    # The patch just adds noise to the PRs. We only really care about overall
+    # coverage
+    patch: off
 
 ignore:
 - "**/setup.py"

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,6 +7,14 @@ What's new in pmdarima
 As new releases of pmdarima are pushed out, the following list (introduced in
 v0.8.1) will document the latest features.
 
+`v1.5.4 <http://alkaline-ml.com/pmdarima/1.5.4/>`_
+--------------------------------------------------
+
+* Support newest versions of matplotlib
+
+* Add new level of ``auto_arima`` error actions: "trace" which will warn for errors while dumping
+  the original stacktrace.
+
 
 `v1.5.3 <http://alkaline-ml.com/pmdarima/1.5.3/>`_
 --------------------------------------------------

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import time
 import warnings
+import traceback
 
 from .arima import ARIMA
 from .warnings import ModelFitWarning
@@ -381,12 +382,13 @@ def _fit_arima(x, xreg, order, seasonal_order, start_params, trend,
     # for non-stationarity errors or singular matrices, return None
     except (LinAlgError, ValueError) as v:
         if error_action == 'warn':
-            # TODO: do we want to use traceback.format_exc()?
             warnings.warn(_fmt_warning_str(order, seasonal_order),
                           ModelFitWarning)
+        elif error_action == 'trace':
+            tb = "\nTraceback:\n" + traceback.format_exc()
+            warning_str = _fmt_warning_str(order, seasonal_order) + tb
+            warnings.warn(warning_str, ModelFitWarning)
         elif error_action == 'raise':
-            # todo: can we do something more informative in case
-            # the error is not on the pmdarima side?
             raise v
         # if it's 'ignore' or 'warn', we just return None
         fit = None
@@ -418,5 +420,5 @@ def _fmt_warning_str(order, seasonal_order):
     """
     return ('Unable to fit ARIMA for %s; data is likely non-stationary. '
             '(if you do not want to see these warnings, run '
-            'with error_action="ignore")'
+            'with error_action="ignore"). '
             % _fmt_order_info(order, seasonal_order))

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -369,7 +369,10 @@ def _fit_arima(x, xreg, order, seasonal_order, start_params, trend,
                trace, error_action,
                out_of_sample_size, scoring, scoring_args,
                with_intercept, **kwargs):
+
+    debug_str = _arima_debug_str(order, seasonal_order, with_intercept)
     start = time.time()
+
     try:
         fit = ARIMA(order=order, seasonal_order=seasonal_order,
                     start_params=start_params, trend=trend, method=method,
@@ -381,24 +384,27 @@ def _fit_arima(x, xreg, order, seasonal_order, start_params, trend,
 
     # for non-stationarity errors or singular matrices, return None
     except (LinAlgError, ValueError) as v:
-        if error_action == 'warn':
-            warnings.warn(_fmt_warning_str(order, seasonal_order),
-                          ModelFitWarning)
-        elif error_action == 'trace':
-            tb = "\nTraceback:\n" + traceback.format_exc()
-            warning_str = _fmt_warning_str(order, seasonal_order) + tb
-            warnings.warn(warning_str, ModelFitWarning)
-        elif error_action == 'raise':
+        if error_action == "raise":
             raise v
-        # if it's 'ignore' or 'warn', we just return None
+
+        elif error_action in ("warn", "trace"):
+            warning_str = 'Error fitting %s ' \
+                          '(if you do not want to see these warnings, run ' \
+                          'with error_action="ignore").' \
+                          % debug_str
+
+            if error_action == 'trace':
+                warning_str += "\nTraceback:\n" + traceback.format_exc()
+
+            warnings.warn(warning_str, ModelFitWarning)
+
         fit = None
 
     # do trace
     if trace:
-        print('Fit ARIMA: %s (constant=%s); AIC=%.3f, BIC=%.3f, '
+        print('Fit %s; AIC=%.3f, BIC=%.3f, '
               'Time=%.3f seconds'
-              % (_fmt_order_info(order, seasonal_order),
-                 with_intercept,
+              % (debug_str,
                  fit.aic() if fit is not None else np.nan,
                  fit.bic() if fit is not None else np.nan,
                  time.time() - start if fit is not None else np.nan))
@@ -406,19 +412,8 @@ def _fit_arima(x, xreg, order, seasonal_order, start_params, trend,
     return fit
 
 
-def _fmt_order_info(order, seasonal_order):
-    return '(%i, %i, %i)x%s' \
-           % (order[0], order[1], order[2],
-              '(%i, %i, %i, %i)'
-              % (seasonal_order[0], seasonal_order[1],
-                 seasonal_order[2], seasonal_order[3]))
-
-
-def _fmt_warning_str(order, seasonal_order):
-    """This is just so we can test that the string will format
-    even if we don't want the warnings in the tests
-    """
-    return ('Unable to fit ARIMA for %s; data is likely non-stationary. '
-            '(if you do not want to see these warnings, run '
-            'with error_action="ignore"). '
-            % _fmt_order_info(order, seasonal_order))
+def _arima_debug_str(order, seasonal_order, with_intercept):
+    p, d, q = order
+    P, D, Q, m = seasonal_order
+    return "ARIMA(%i,%i,%i)x(%i,%i,%i,%i) [intercept=%r]" % \
+           (p, d, q, P, D, Q, m, with_intercept)

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -60,7 +60,7 @@ class AutoARIMA(BaseARIMA):
                  test='kpss', seasonal_test='ocsb', stepwise=True, n_jobs=1,
                  start_params=None, trend=None, method='lbfgs', maxiter=50,
                  offset_test_args=None, seasonal_test_args=None,
-                 suppress_warnings=False, error_action='warn', trace=False,
+                 suppress_warnings=False, error_action='trace', trace=False,
                  random=False, random_state=None, n_fits=10,
                  out_of_sample_size=0, scoring='mse',
                  scoring_args=None, with_intercept=True,
@@ -260,7 +260,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
                test='kpss', seasonal_test='ocsb', stepwise=True, n_jobs=1,
                start_params=None, trend=None, method='lbfgs', maxiter=50,
                offset_test_args=None, seasonal_test_args=None,
-               suppress_warnings=False, error_action='warn', trace=False,
+               suppress_warnings=False, error_action='trace', trace=False,
                random=False, random_state=None, n_fits=10,
                return_valid_fits=False, out_of_sample_size=0, scoring='mse',
                scoring_args=None, with_intercept=True,
@@ -312,7 +312,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
                          'for a random search')
 
     # validate error action
-    actions = {'warn', 'raise', 'ignore', None}
+    actions = {'warn', 'raise', 'ignore', 'trace', None}
     if error_action not in actions:
         raise ValueError('error_action must be one of %r, but got %r'
                          % (actions, error_action))

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -2,7 +2,6 @@
 
 from pmdarima.arima import ARIMA, auto_arima, AutoARIMA
 from pmdarima.arima.arima import VALID_SCORING, _uses_legacy_pickling
-from pmdarima.arima._auto_solvers import _fmt_warning_str
 from pmdarima.arima.auto import _post_ppc_arima
 from pmdarima.arima.utils import nsdiffs
 from pmdarima.arima.warnings import ModelFitWarning
@@ -682,12 +681,6 @@ def test_corner_cases():
     # show if max* < start* it breaks:
     with pytest.raises(ValueError):
         auto_arima(np.ones(10), start_p=5, max_p=0)
-
-
-def test_warning_str_fmt():
-    order = (1, 1, 1)
-    seasonal = (1, 1, 1, 1)
-    _fmt_warning_str(order, seasonal)
 
 
 @pytest.mark.parametrize(

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -814,7 +814,7 @@ def test_seasonal_xreg_differencing():
 def test_inf_max_order():
     _ = auto_arima(lynx, max_order=None,  # noqa: F841
                    suppress_warnings=True,
-                   error_action='ignore')
+                   error_action='trace')
 
 
 # Regression testing for unpickling an ARIMA from an older version


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Adds a new `error_action` level, "trace". This behaves like "warn" but dumps the stacktrace as well instead of the generic `may not be stationary` message

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
