### PR TITLE
[MRG+2] Fix for issue#316 decompose error where m is odd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# VS Code
+.vscode/
+
 # Mac stuff
 .DS_Store
 .idea/

--- a/pmdarima/arima/seasonality.py
+++ b/pmdarima/arima/seasonality.py
@@ -83,6 +83,7 @@ def decompose(x, type_, m, filter_=None):
 
     multiplicative = "multiplicative"
     additive = "additive"
+    is_m_odd = (m % 2 == 1)
 
     # Helper function to stay consistent and concise based on 'type_'
     def _decomposer_helper(a, b):
@@ -114,7 +115,9 @@ def decompose(x, type_, m, filter_=None):
     # Take half of m for the convolution / sma process.
     half_m = m // 2
     trend = np.convolve(x, filter_, mode='valid')
-    trend = trend[:-1]  # we remove the final index.
+
+    if not is_m_odd:
+        trend = trend[:-1]  # we remove the final index if m is even.
 
     # Remove the effect of the trend on the original signal and pad for reshape
     sma_xs = range(half_m, len(trend) + half_m)
@@ -134,6 +137,8 @@ def decompose(x, type_, m, filter_=None):
         seasonal = np.concatenate((seasonal, temp))
     if pad_length > 0:
         seasonal = seasonal[:-pad_length]
+    if is_m_odd:
+        seasonal = seasonal[:-1]
 
     # We buffer the trend and seasonal components so that they are the same
     # length as the other outputs. This counters the effects of losing data

--- a/pmdarima/arima/tests/test_seasonality.py
+++ b/pmdarima/arima/tests/test_seasonality.py
@@ -24,9 +24,10 @@ austres_long = np.asarray(aus_list * 10)  # type: np.ndarray
 
 @pytest.mark.parametrize(
     'x,type_,m,filter_', [
-        pytest.param(ausbeer, 'additive', 4, None),
-        pytest.param(airpassengers, 'multiplicative', 12, None),
-        pytest.param(wineind, 'additive', 12, None)
+        pytest.param(ausbeer, 'additive', 4, None)
+        ,pytest.param(airpassengers, 'multiplicative', 12, None)
+        ,pytest.param(wineind, 'additive', 12, None)
+        ,pytest.param(np.array([1., 2., 3., 4., 5., 6.,]), 'additive', 3, None) # issue#316 : test where m is odd
     ]
 )
 def test_decompose_happy_path(x, type_, m, filter_):

--- a/pmdarima/arima/tests/test_seasonality.py
+++ b/pmdarima/arima/tests/test_seasonality.py
@@ -24,10 +24,10 @@ austres_long = np.asarray(aus_list * 10)  # type: np.ndarray
 
 @pytest.mark.parametrize(
     'x,type_,m,filter_', [
-        pytest.param(ausbeer, 'additive', 4, None)
-        ,pytest.param(airpassengers, 'multiplicative', 12, None)
-        ,pytest.param(wineind, 'additive', 12, None)
-        ,pytest.param(np.array([1., 2., 3., 4., 5., 6.,]), 'additive', 3, None) # issue#316 : test where m is odd
+        pytest.param(ausbeer, 'additive', 4, None), 
+        pytest.param(airpassengers, 'multiplicative', 12, None), 
+        pytest.param(wineind, 'additive', 12, None), 
+        pytest.param(np.array([1., 2., 3., 4., 5., 6.]), 'additive', 3, None)
     ]
 )
 def test_decompose_happy_path(x, type_, m, filter_):

--- a/pmdarima/arima/tests/test_seasonality.py
+++ b/pmdarima/arima/tests/test_seasonality.py
@@ -24,9 +24,9 @@ austres_long = np.asarray(aus_list * 10)  # type: np.ndarray
 
 @pytest.mark.parametrize(
     'x,type_,m,filter_', [
-        pytest.param(ausbeer, 'additive', 4, None), 
-        pytest.param(airpassengers, 'multiplicative', 12, None), 
-        pytest.param(wineind, 'additive', 12, None), 
+        pytest.param(ausbeer, 'additive', 4, None),
+        pytest.param(airpassengers, 'multiplicative', 12, None),
+        pytest.param(wineind, 'additive', 12, None),
         pytest.param(np.array([1., 2., 3., 4., 5., 6.]), 'additive', 3, None)
     ]
 )


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies
that are required for this change.

Fixes #316 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Please also list any relevant details
for your test configuration

- [x] Add a unittest that tests the exact configuration noted within the issue
- [x] Validated behavior with [R's decompose interactive editor](https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/decompose) using the following configuration against unittest:

**Input/Code**
```R
# NOT RUN {
require(graphics)

## example taken from Kendall/Stuart
x <- c(1, 2, 3, 4, 5, 6)
x <- ts(x, frequency = 3)
m <- decompose(x)
m
## seasonal figure: 6.25, 8.62, -8.84, -6.03
# round(decompose(x)$figure / 10, 2)
# }
```
**Output**
```R
> # NOT RUN {
> require(graphics)
> 
> ## example taken from Kendall/Stuart
> x <- c(1, 2, 3, 4, 5, 6)
> x <- ts(x, frequency = 3)
> m <- decompose(x)
> m
$x
Time Series:
Start = c(1, 1) 
End = c(2, 3) 
Frequency = 3 
[1] 1 2 3 4 5 6

$seasonal
Time Series:
Start = c(1, 1) 
End = c(2, 3) 
Frequency = 3 
[1] -1.850372e-16 -7.401487e-17  2.590520e-16 -1.850372e-16 -7.401487e-17
[6]  2.590520e-16

$trend
Time Series:
Start = c(1, 1) 
End = c(2, 3) 
Frequency = 3 
[1] NA  2  3  4  5 NA

$random
Time Series:
Start = c(1, 1) 
End = c(2, 3) 
Frequency = 3 
[1]           NA 2.220446e-16 0.000000e+00 0.000000e+00 0.000000e+00
[6]           NA

$figure
[1] -1.850372e-16 -7.401487e-17  2.590520e-16

$type
[1] "additive"

attr(,"class")
[1] "decomposed.ts"
> ## seasonal figure: 6.25, 8.62, -8.84, -6.03
> # round(decompose(x)$figure / 10, 2)
> # }
> 
```
**Python Testing**
```python
>>> import numpy as np
>>> from pmdarima import arima
>>> tarray =np.array([1.,2.,3.,4.,5.,6.,])
>>> arima.decompose(tarray, 'additive', m=3)
trend:  [2. 3. 4. 5.]
trend (buffered):  [nan, 2.0, 3.0, 3.9999999999999996, 5.0, nan]
_a.shape: (6,)
seasonal.shape: (6,)
decomposed(x=array([1., 2., 3., 4., 5., 6.]), trend=[nan, 2.0, 3.0, 3.9999999999999996, 5.0, nan], seasonal=array([0.0000000e+00, 4.4408921e-16, 0.0000000e+00, 0.0000000e+00,
       4.4408921e-16, 0.0000000e+00]), random=array([           nan, -4.4408921e-16,  0.0000000e+00,  4.4408921e-16,
       -4.4408921e-16,            nan]))
>>> exit()
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
