### PR TITLE
[MRG+1] Avoid KeyError on downloads badge script

### DIFF
--- a/etc/downloads_badges.py
+++ b/etc/downloads_badges.py
@@ -76,11 +76,11 @@ pmdarima = json.loads(session.get('https://api.pepy.tech/api/projects/pmdarima')
 
 # Sum up pmdarima and pyramid-arima downloads to the past week
 pmdarima_downloads = 0
-default_pmpdarima_value = get_default_value(pmdarima['downloads'])
+default_pmdarima_value = get_default_value(pmdarima['downloads'])
 for i in range(7):
     pmdarima_downloads += pmdarima['downloads'].get(
         (last_week + timedelta(days=i)).strftime(DATE_FORMAT),
-        default_pmpdarima_value
+        default_pmdarima_value
     )
 
 pyramid_arima_downloads = 0

--- a/etc/downloads_badges.py
+++ b/etc/downloads_badges.py
@@ -54,8 +54,8 @@ def get_default_value(downloads):
     Returns
     -------
     default_value : int
-        The default value, which is the average of the last 7 days of downloads that are contained in the input
-        dictionary.
+        The default value, which is the average of the last 7 days of downloads
+        that are contained in the input dictionary.
     """
     last_7_keys = sorted(downloads.keys())[-7:]
     default_value = int(mean([downloads[key] for key in last_7_keys]))


### PR DESCRIPTION

# Description

The website we depend on for our downloads badge did not update and we got an [error](https://github.com/alkaline-ml/pmdarima/actions/runs/76033812) due to trying to access a key that did not exist. This PR implements `dict.get(key, default)` instead of `dict[key]` by calculating the default as the average of the last week before summing the values

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Please also list any relevant details
for your test configuration

- [x] Tested locally and it works fine. I doubt we will run into this issue often

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
