### PR TITLE
[MRG+1] ValueError for predict_in_sample when start < d

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,7 +22,7 @@ v0.8.1) will document the latest features.
 
 * Patch broken Anaconda Cloud releases
 
-* Produce a warnings in ``arima.predict_in_sample`` when ``start < d``
+* Raise a ``ValueError`` in ``arima.predict_in_sample`` when ``start < d``
 
 
 `v1.5.3 <http://alkaline-ml.com/pmdarima/1.5.3/>`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,8 @@ v0.8.1) will document the latest features.
 
 * Patch broken Anaconda Cloud releases
 
+* Produce a warnings in ``arima.predict_in_sample`` when ``start < d``
+
 
 `v1.5.3 <http://alkaline-ml.com/pmdarima/1.5.3/>`_
 --------------------------------------------------

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -2,8 +2,8 @@
 #
 # Author: Taylor Smith <taylor.smith@alkaline-ml.com>
 #
-# A much more user-friendly wrapper to the statsmodels ARIMA.
-# Mimics the familiar sklearn interface.
+# A user-friendly wrapper to the statsmodels ARIMA that mimics the familiar
+# sklearn interface.
 
 from sklearn.metrics import mean_absolute_error, mean_squared_error
 from sklearn.utils.metaestimators import if_delegate_has_method
@@ -22,7 +22,6 @@ from ..compat.numpy import DTYPE  # DTYPE for arrays
 from ..compat.sklearn import get_compatible_check_is_fitted, safe_indexing
 from ..compat import statsmodels as sm_compat
 from ..compat import matplotlib as mpl_compat
-from ..compat.matplotlib import mpl_hist_arg
 from ..utils import get_callable, if_has_delegate, is_iterable, check_endog, \
     check_exog
 from ..utils.visualization import _get_plt
@@ -556,7 +555,14 @@ class ARIMA(BaseARIMA):
         # TODO: remove this, it's a compat check
         if kwargs.pop("typ", None):
             warnings.warn("As of version 1.5.0 'typ' is no longer a valid "
-                          "arg for predict")
+                          "arg for predict. In future versions this will "
+                          "raise a TypeError.")
+
+        # issue #286
+        d = self.order[1]
+        if start is not None and start < d:
+            warnings.warn("In-sample predictions undefined for start={0} when "
+                          "d={1}".format(start, d))
 
         # if we fit with exog, make sure one was passed:
         exogenous = self._check_exog(exogenous)  # type: np.ndarray

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -522,7 +522,8 @@ class ARIMA(BaseARIMA):
 
         start : int, optional (default=None)
             Zero-indexed observation number at which to start forecasting, ie.,
-            the first forecast is start.
+            the first forecast is start. Note that if this value is less than
+            ``d``, the order of differencing, an error will be raised.
 
         end : int, optional (default=None)
             Zero-indexed observation number at which to end forecasting, ie.,
@@ -558,11 +559,12 @@ class ARIMA(BaseARIMA):
                           "arg for predict. In future versions this will "
                           "raise a TypeError.")
 
-        # issue #286
+        # issue #286: we cannot produce valid predictions for a period earlier
+        # than the differencing value
         d = self.order[1]
         if start is not None and start < d:
-            warnings.warn("In-sample predictions undefined for start={0} when "
-                          "d={1}".format(start, d))
+            raise ValueError("In-sample predictions undefined for start={0} "
+                             "when d={1}".format(start, d))
 
         # if we fit with exog, make sure one was passed:
         exogenous = self._check_exog(exogenous)  # type: np.ndarray

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -1035,9 +1035,9 @@ def test_issue_286():
     mod = ARIMA(order=(1, 1, 2))
     mod.fit(wineind)
 
-    with pytest.warns(UserWarning,
-                      match="In-sample predictions undefined for"):
+    with pytest.raises(ValueError) as ve:
         mod.predict_in_sample(start=0)
+    assert "In-sample predictions undefined for" in pytest_error_str(ve)
 
 
 @pytest.mark.parametrize(

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -1031,6 +1031,15 @@ def test_issue_104(model):
     assert not np.array_equal(preds1, preds2)
 
 
+def test_issue_286():
+    mod = ARIMA(order=(1, 1, 2))
+    mod.fit(wineind)
+
+    with pytest.warns(UserWarning,
+                      match="In-sample predictions undefined for"):
+        mod.predict_in_sample(start=0)
+
+
 @pytest.mark.parametrize(
     'model', [
         # ARMA


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

This fixes #286 by adding a ValueError in `predict_in_sample` when `start < d`, a condition for which in-sample predictions are undefined. I originally considered a warning, but in this case, where we're liable to have users ignore a warning and ask why they get junky predictions for the early portion of their series, I do think an error will be best.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change

# How Has This Been Tested?

Added a new test that reproduces and catches the error to assert it is raised as expected.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes