### PR TITLE
MAINT: Set a ceiling on cython version

### DIFF
--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -1,7 +1,6 @@
 numpy>=1.17.3
 scipy>=1.3.2
-# Pin Cython to avoid bug with 0.28.x on Python 3.7
-cython>=0.29
+cython>=0.29,<0.29.18
 scikit-learn>=0.22
 pandas>=0.19
 statsmodels>=0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Cython>=0.29
 joblib>=0.11
+Cython>=0.29,<0.29.18
 numpy>=1.17.3
 pandas>=0.19
 scikit-learn>=0.22


### PR DESCRIPTION
The latest Cython was released last night and conflicts with the latest Numpy version. Since we use `numpy.distutils` to build, our nightly jobs are failing. We originally pinned `Cython>=0.29`, but this PR adds a ceiling of `<0.29.18` to avoid build failures until Numpy is compatible with the latest Cython.