### PR TITLE
[MRG+1] Bump our doc requirements as well

### DIFF
--- a/build_tools/doc/doc_requirements.txt
+++ b/build_tools/doc/doc_requirements.txt
@@ -1,9 +1,9 @@
-Cython>=0.29
+Cython>=0.29,<0.29.18
 numpy>=1.16
 scipy>=1.3
 scikit-learn>=0.19
 pandas>=0.19
-statsmodels>=0.10.2
+statsmodels>=0.11
 sphinx==1.7.2
 sphinx_gallery==0.1.13
 sphinx_rtd_theme


### PR DESCRIPTION

# Description

We bumped our Cython requirements in #335, and our statsmodels requirements in #334, but we only updated  `requirements.txt` and `build_requirements.txt`, but forgot `doc_requirements.txt`. I don't think this affected the deploy of `1.6.1` -- the docs look correct, but I wanted to update it to keep everything in sync.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
