### PR TITLE
[MRG+1] Fix to_dict test

### DIFF
--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -11,7 +11,7 @@ from pmdarima.datasets import load_lynx, load_wineind, load_heartrate, \
 from pmdarima.utils import get_callable
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_almost_equal, assert_allclose
 from numpy.random import RandomState
 
 import joblib
@@ -949,14 +949,14 @@ def test_to_dict_is_accurate():
 
     assert actual.keys() == expected.keys()
     assert_almost_equal(actual['pvalues'], expected['pvalues'], decimal=5)
-    assert_almost_equal(actual['resid'], expected['resid'], decimal=5)
+    assert_allclose(actual['resid'], expected['resid'], rtol=1e-3)
     assert actual['order'] == expected['order']
     assert actual['seasonal_order'] == expected['seasonal_order']
     assert np.isnan(actual['oob'])
     assert_almost_equal(actual['aic'], expected['aic'], decimal=5)
     assert_almost_equal(actual['aicc'], expected['aicc'], decimal=5)
     assert_almost_equal(actual['bic'], expected['bic'], decimal=5)
-    assert_almost_equal(actual['bse'], expected['bse'], decimal=3)
+    assert_allclose(actual['bse'], expected['bse'], rtol=1e-3)
     assert_almost_equal(actual['params'], expected['params'], decimal=3)
 
 

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -11,7 +11,8 @@ from pmdarima.datasets import load_lynx, load_wineind, load_heartrate, \
 from pmdarima.utils import get_callable
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_almost_equal, assert_allclose
+from numpy.testing import assert_array_almost_equal, assert_almost_equal, \
+    assert_allclose
 from numpy.random import RandomState
 
 import joblib


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Related to #348, scipy 1.5.0 seems to have changed the internals of our function `AutoARIMA` class. No big deal, but our `to_dict` test is broken because we are comparing to hardcoded values generated using a previous release. It seems only `resid` and `bse` were really affected, from my digging. The short-term solution is to use `assert_allclose` with a high `rtol` for those tests

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Tests pass locally and on CI/CD

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
