### PR TITLE
[MRG+1] Emit warnings / custom errors for differencing issues

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,6 +8,17 @@ As new releases of pmdarima are pushed out, the following list (introduced in
 v0.8.1) will document the latest features.
 
 
+`v1.7.0 <http://alkaline-ml.com/pmdarima/1.7.0/>`_
+--------------------------------------------------
+
+* Address issue `#341 <https://github.com/alkaline-ml/pmdarima/issues/341>`_ where
+  a combination of a large ``m`` value and ``D`` value could difference an array into
+  being too small to test stationarity in the ADF test
+
+* Fix issue `#351 <https://github.com/alkaline-ml/pmdarima/issues/351>`_ where a large
+  value of ``m`` could prevent the seasonality test from completing.
+
+
 `v1.6.1 <http://alkaline-ml.com/pmdarima/1.6.1/>`_
 --------------------------------------------------
 

--- a/pmdarima/__init__.py
+++ b/pmdarima/__init__.py
@@ -54,7 +54,10 @@ else:
     # Need these namespaces at the top so they can be used like:
     # pm.datasets.load_wineind()
     from . import arima
+    from . import compat
     from . import datasets
+    from . import model_selection
+    from . import preprocessing
     from . import utils
 
     __all__ = [

--- a/pmdarima/__init__.py
+++ b/pmdarima/__init__.py
@@ -55,7 +55,9 @@ else:
     # pm.datasets.load_wineind()
     from . import arima
     from . import compat
+    from . import context_managers
     from . import datasets
+    from . import decorators
     from . import model_selection
     from . import preprocessing
     from . import utils
@@ -64,7 +66,9 @@ else:
         # Namespaces we want exposed at top:
         'arima',
         'compat',
+        'context_managers',
         'datasets',
+        'decorators',
         'model_selection',
         'preprocessing',
         'utils',

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -22,7 +22,6 @@ from ._context import AbstractContext, ContextType
 from . import _auto_solvers as solvers
 from ..compat.numpy import DTYPE
 from ..compat import statsmodels as sm_compat
-from .. import context_managers as ctx
 
 __all__ = [
     'auto_arima',
@@ -442,23 +441,11 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         offset_test_args = offset_test_args \
             if offset_test_args is not None else dict()
 
-        # Numpy can raise if we've seasonal-differenced the array into oblivion
-        with ctx.except_and_reraise(
-                np.linalg.LinAlgError,
-                "Last 2 dimensions of the array must be square",
-                ValueError,
-                "Encountered exception in stationarity test (%r). "
-                "This can occur when a large `m` (currently set to %i) "
-                "coupled with a large enough `D` (currently set to %i) "
-                "difference the training array into too few samples for OLS. "
-                "Try fitting on a larger training size"
-                % (test, m, D),
-        ):
-            d = ndiffs(dx,
-                       test=test,
-                       alpha=alpha,
-                       max_d=max_d,
-                       **offset_test_args)
+        d = ndiffs(dx,
+                   test=test,
+                   alpha=alpha,
+                   max_d=max_d,
+                   **offset_test_args)
 
         if d > 0 and exogenous is not None:
             diffxreg = diff(diffxreg, differences=d, lag=1)

--- a/pmdarima/arima/tests/test_auto.py
+++ b/pmdarima/arima/tests/test_auto.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from pmdarima.arima import auto
+from pmdarima.compat.pytest import pytest_error_str
 import pytest
 
 
@@ -25,7 +26,7 @@ def test_issue_341():
          191, 234, 253, 155, 25, 0, 228, 234, 265, 205, 191, 19, 0, 188,
          156, 172, 173, 166, 28, 0, 209, 160, 159, 129, 124, 18, 0, 155]
 
-    try:
+    with pytest.raises(ValueError) as ve:
         auto.auto_arima(
             y,
             start_p=1,
@@ -46,7 +47,4 @@ def test_issue_341():
 
     # assert that we catch the np LinAlg error and reraise with a more
     # meaningful message
-    except ValueError as v:
-        assert "Encountered exception in stationarity test" in str(v)
-    else:
-        assert False, "Expected test to fail"
+    assert "Encountered exception in stationarity test" in pytest_error_str(ve)

--- a/pmdarima/arima/tests/test_auto.py
+++ b/pmdarima/arima/tests/test_auto.py
@@ -17,3 +17,36 @@ def test_deprecation_warnings_on_class():
     with pytest.warns(DeprecationWarning) as we:
         auto.AutoARIMA(sarimax_kwargs={"simple_differencing": True})
     assert we
+
+
+def test_issue_341():
+    y = [0, 132, 163, 238, 29, 0, 150, 320, 249, 224, 197, 31, 0, 154,
+         143, 132, 135, 158, 21, 0, 126, 100, 137, 105, 104, 8, 0, 165,
+         191, 234, 253, 155, 25, 0, 228, 234, 265, 205, 191, 19, 0, 188,
+         156, 172, 173, 166, 28, 0, 209, 160, 159, 129, 124, 18, 0, 155]
+
+    try:
+        auto.auto_arima(
+            y,
+            start_p=1,
+            start_q=1,
+            test='adf',
+            max_p=3,
+            max_q=3,
+            m=52,
+            start_P=0,
+            seasonal=True,
+            d=None,
+            D=1,
+            trace=True,
+            error_action='ignore',
+            suppress_warnings=True,
+            stepwise=True
+        )
+
+    # assert that we catch the np LinAlg error and reraise with a more
+    # meaningful message
+    except ValueError as v:
+        assert "Encountered exception in stationarity test" in str(v)
+    else:
+        assert False, "Expected test to fail"

--- a/pmdarima/arima/tests/test_utils.py
+++ b/pmdarima/arima/tests/test_utils.py
@@ -3,8 +3,17 @@
 import numpy as np
 import pytest
 
-from pmdarima.arima.utils import nsdiffs
-from pmdarima.compat.pytest import pytest_warning_messages
+from pmdarima.arima import utils as arima_utils
+from pmdarima.compat.pytest import pytest_warning_messages, pytest_error_str
+
+
+def test_issue_341():
+    seas_diffed = np.array([124., -114., -163., -83.])
+
+    with pytest.raises(ValueError) as ve:
+        arima_utils.ndiffs(seas_diffed, test='adf')
+
+    assert "raised from LinAlgError" in pytest_error_str(ve)
 
 
 def test_issue_351():
@@ -16,7 +25,7 @@ def test_issue_351():
     ])
 
     with pytest.warns(UserWarning) as w_list:
-        D = nsdiffs(y, m=52, max_D=2, test='ocsb')
+        D = arima_utils.nsdiffs(y, m=52, max_D=2, test='ocsb')
 
     assert D == 1
 

--- a/pmdarima/arima/tests/test_utils.py
+++ b/pmdarima/arima/tests/test_utils.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+from pmdarima.arima.utils import nsdiffs
+from pmdarima.compat.pytest import pytest_warning_messages
+
+
+def test_issue_351():
+    y = np.array([
+        1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 2, 1, 6, 2, 1, 0,
+        2, 0, 1, 0, 0, 3, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 0, 0, 6,
+        0, 0, 0, 0, 0, 1, 3, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0
+    ])
+
+    with pytest.warns(UserWarning) as w_list:
+        D = nsdiffs(y, m=52, max_D=2, test='ocsb')
+
+    assert D == 1
+
+    warnings_messages = pytest_warning_messages(w_list)
+    assert len(warnings_messages) == 1
+    assert 'shorter than m' in warnings_messages[0]

--- a/pmdarima/arima/utils.py
+++ b/pmdarima/arima/utils.py
@@ -7,6 +7,8 @@
 from sklearn.utils.validation import column_or_1d
 import numpy as np
 
+import warnings
+
 from ..utils import get_callable
 from ..utils.array import diff, check_endog
 from ..compat.numpy import DTYPE
@@ -107,6 +109,16 @@ def nsdiffs(x, m, max_D=2, test='ocsb', **kwargs):
 
         if is_constant(x):
             return D
+
+        # Issue 351: if the differenced array is now shorter than the seasonal
+        # periodicity, we need to bail out now.
+        if len(x) < m:
+            warnings.warn("Appropriate D value may not have been reached; "
+                          "length of seasonally-differenced array (%i) is "
+                          "shorter than m (%i). Using D=%i"
+                          % (len(x), m, D))
+            return D
+
         dodiff = testfunc(x)
 
     return D

--- a/pmdarima/arima/utils.py
+++ b/pmdarima/arima/utils.py
@@ -160,7 +160,8 @@ def ndiffs(x, alpha=0.05, test='kpss', max_d=2, **kwargs):
 
     References
     ----------
-    .. [1] R's auto_arima ndiffs function: https://bit.ly/2Bu8CHN
+    .. [1] R's auto_arima ndiffs function
+           https://github.com/robjhyndman/forecast/blob/19b0711e554524bf6435b7524517715658c07699/R/arima.R#L132  # noqa: E501
     """
     if max_d <= 0:
         raise ValueError('max_d must be a positive integer')

--- a/pmdarima/compat/pytest.py
+++ b/pmdarima/compat/pytest.py
@@ -7,3 +7,8 @@ def pytest_error_str(error):
         return str(error.value)
     except AttributeError:
         return str(error)
+
+
+def pytest_warning_messages(warnings):
+    """Get the warning messages for captured warnings"""
+    return [str(w.message) for w in warnings.list]

--- a/pmdarima/context_managers.py
+++ b/pmdarima/context_managers.py
@@ -6,22 +6,34 @@ __all__ = ['except_and_reraise']
 
 
 @contextlib.contextmanager
-def except_and_reraise(except_err, except_msg, raise_err, raise_msg):
+def except_and_reraise(*except_errs, raise_err=None, raise_msg=None):
     """Catch a lower-level error and re-raise with a more meaningful message
 
     In some cases, Numpy linalg errors can be raised in perplexing spots. This
     allows us to catch the lower-level errors in spots where we are aware of
     them so that we may raise with a more meaningful message.
+
+    Parameters
+    ----------
+    *except_errs : var-args, BaseException
+        A variable list of exceptions to catch
+
+    raise_err : BaseException, Error
+        The exception to raise
+
+    raise_msg : str
+        The message to raise
     """
+    if raise_err is None:
+        raise TypeError("raise_err must be used as a key-word arg")
+    if raise_msg is None:
+        raise TypeError("raise_msg must be used as a key-word arg")
+
     try:
         yield
-    except except_err as e:
-        if except_msg in str(e):
-            message = "%s (raised from %s: %s)" \
-                      % (raise_msg,
-                         except_err.__name__,
-                         str(e))
-            raise raise_err(message)
-
-        # otherwise raise it raw
-        raise
+    except except_errs as e:
+        message = "%s (raised from %s: %s)" \
+                  % (raise_msg,
+                     e.__class__.__name__,
+                     str(e))
+        raise raise_err(message)

--- a/pmdarima/context_managers.py
+++ b/pmdarima/context_managers.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import contextlib
+
+__all__ = ['except_and_reraise']
+
+
+@contextlib.contextmanager
+def except_and_reraise(except_err, except_msg, raise_err, raise_msg):
+    """Catch a lower-level error and re-raise with a more meaningful message
+
+    In some cases, Numpy linalg errors can be raised in perplexing spots. This
+    allows us to catch the lower-level errors in spots where we are aware of
+    them so that we may raise with a more meaningful message.
+    """
+    try:
+        yield
+    except except_err as e:
+        if except_msg in str(e):
+            message = "%s (raised from %s: %s)" \
+                      % (raise_msg,
+                         except_err.__name__,
+                         str(e))
+            raise raise_err(message)
+
+        # otherwise raise it raw
+        raise

--- a/pmdarima/tests/test_context_managers.py
+++ b/pmdarima/tests/test_context_managers.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from pmdarima import context_managers as ctx
+
+
+def test_except_and_reraise_do_reraise():
+    try:
+        with ctx.except_and_reraise(
+                ValueError, "foo message", KeyError, "bar message"
+        ):
+            raise ValueError("contains foo message")
+    except KeyError as k:
+        assert "bar message" in str(k)
+        assert "raised from ValueError" in str(k)
+    else:
+        assert False, "Test failed"
+
+
+def test_except_and_reraise_no_reraise():
+    try:
+        with ctx.except_and_reraise(
+                ValueError, "foo message", KeyError, "bar message"
+        ):
+            raise ValueError("some other error")
+    except ValueError as v:
+        assert "some other error" in str(v)
+    else:
+        assert False, "Test failed"

--- a/pmdarima/tests/test_context_managers.py
+++ b/pmdarima/tests/test_context_managers.py
@@ -7,32 +7,29 @@ import pytest
 
 
 def test_except_and_reraise_do_reraise():
-    try:
+    with pytest.raises(KeyError) as ke:
         with ctx.except_and_reraise(
                 ValueError,
                 raise_err=KeyError,
                 raise_msg="bar message"
         ):
             raise ValueError("contains foo message")
-    except KeyError as k:
-        assert "bar message" in str(k)
-        assert "raised from ValueError" in str(k)
-    else:
-        assert False, "Test failed"
+
+    msg = pytest_error_str(ke)
+    assert "bar message" in msg
+    assert "raised from ValueError" in msg
 
 
 def test_except_and_reraise_no_reraise():
-    try:
+    with pytest.raises(KeyError) as ke:
         with ctx.except_and_reraise(
                 ValueError,
                 raise_err=TypeError,
                 raise_msg="bar message"
         ):
             raise KeyError("foo message")
-    except KeyError as v:
-        assert "foo message" in str(v)
-    else:
-        assert False, "Test failed"
+
+    assert "foo message" in pytest_error_str(ke)
 
 
 @pytest.mark.parametrize('err', [ValueError, KeyError, TypeError])

--- a/pmdarima/tests/test_context_managers.py
+++ b/pmdarima/tests/test_context_managers.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 
 from pmdarima import context_managers as ctx
+from pmdarima.compat.pytest import pytest_error_str
+
+import pytest
 
 
 def test_except_and_reraise_do_reraise():
     try:
         with ctx.except_and_reraise(
-                ValueError, "foo message", KeyError, "bar message"
+                ValueError,
+                raise_err=KeyError,
+                raise_msg="bar message"
         ):
             raise ValueError("contains foo message")
     except KeyError as k:
@@ -19,10 +24,29 @@ def test_except_and_reraise_do_reraise():
 def test_except_and_reraise_no_reraise():
     try:
         with ctx.except_and_reraise(
-                ValueError, "foo message", KeyError, "bar message"
+                ValueError,
+                raise_err=TypeError,
+                raise_msg="bar message"
         ):
-            raise ValueError("some other error")
-    except ValueError as v:
-        assert "some other error" in str(v)
+            raise KeyError("foo message")
+    except KeyError as v:
+        assert "foo message" in str(v)
     else:
         assert False, "Test failed"
+
+
+@pytest.mark.parametrize('err', [ValueError, KeyError, TypeError])
+def test_multiple(err):
+
+    class FooError(BaseException):
+        pass
+
+    with pytest.raises(FooError) as fe:
+        with ctx.except_and_reraise(
+                ValueError, KeyError, TypeError,
+                raise_err=FooError,
+                raise_msg="gotcha, fam",
+        ):
+            raise err("Boo!")
+
+    assert "gotcha, fam" in pytest_error_str(fe)


### PR DESCRIPTION

# Description

Two recent issues pointed out areas where a large enough `m` could seasonally difference an array into being too small for fitting downstream models. This PR adds a custom error for #341 and a warning for #351 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change

# How Has This Been Tested?

Added new tests that capture the warning / custom error and assert on them.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
