### PR TITLE
[MRG+1] Ignore warnings we don't care about in tests

### DIFF
--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -773,6 +773,7 @@ def test_warn_for_stepwise_and_parallel():
 
 
 # Force case where data is simple polynomial after differencing
+@pytest.mark.filterwarnings('ignore:divide by zero')  # Expected, so ignore
 def test_force_polynomial_error():
     x = np.array([1, 2, 3, 4, 5, 6])
     d = 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,5 +11,15 @@ filterwarnings =
     # Warnings that statsmodels raises a lot of
     ignore::statsmodels.tools.sm_exceptions.HessianInversionWarning
 
+    # statsmodels warning that doesn't apply to us
+    ignore:fft=True
+
+    # joblib warning that we can't control (fixed in this commit https://github.com/joblib/joblib/commit/a861f43167ab63fe683c45679e34143751cb976d, but not deployed yet)
+    # This is the solution from pytest: https://github.com/pytest-dev/pytest/issues/4116#issuecomment-429101898
+    ignore:tostring.*is deprecated
+
+    # This is fixed in patsy... No idea which dependency is actually calling patsy (https://github.com/pydata/patsy/blob/4c613d0ad3009044ca3aee5a5d70bd56af8f396b/patsy/constraint.py#L13-L16)
+    ignore:Using or importing the ABCs
+
 [metadata]
 description-file = README.md


### PR DESCRIPTION
 # Description

I am unable to replicate @tgsmith61591's local experience:

`360 passed, 9673 warnings in 162.20s (0:02:42)`

But I was able to take my local (and CI) from this:

`360 passed, 1677 warnings in 129.89s (0:02:09)`

To this:

`360 passed in 110.10s (0:01:50)`

We were basically seeing 4 warnings:

- `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping`
    - This is [fixed in patsy](https://github.com/pydata/patsy/blob/4c613d0ad3009044ca3aee5a5d70bd56af8f396b/patsy/constraint.py#L13-L16), but I don't even know what is calling patsy, so we ignore it
- `DeprecationWarning: tostring() is deprecated. Use tobytes() instead.` (1672 of the warnings)
    - This is fixed in [`joblib`](https://github.com/joblib/joblib/commit/a861f43167ab63fe683c45679e34143751cb976d), but not deployed yet, so we can ignore it
- ` RuntimeWarning: divide by zero encountered in reciprocal`
    - We expect this in `test_force_polynomial_error`, so we can ignore it
- `FutureWarning: fft=True will become the default in a future version of statsmodels. To suppress this warning, explicitly set fft=False.`
    - We already pass in `fft` explicitly, so we don't really care about the default

## Type of change

- [X] Tests changes

# How Has This Been Tested?

- [X] Tests pass, and now with no warnings 🎉

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
