### PR TITLE
[MRG] Address issue #354

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -103,8 +103,8 @@ rules may hinder the speed with which your contribution is merged:
 
 .. _filing_bugs:
 
-Filing bugs
------------
+Filing a bug
+------------
 We use Github issues to track all bugs and feature requests; feel free to
 open an issue if you have found a bug or wish to see a feature implemented.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,6 +37,7 @@ Helpful sections to get started:
 * :ref:`contrib`
 * :ref:`contributors`
 * :ref:`citing`
+* :ref:`no_successful_model`
 * :ref:`quickstart`
 * :ref:`user_guide`
 
@@ -47,6 +48,7 @@ Other versions
 
 Documentation for other release versions of ``pmdarima``:
 
+* `v1.7.0 <http://alkaline-ml.com/pmdarima/1.7.0>`_
 * `v1.6.1 <http://alkaline-ml.com/pmdarima/1.6.1>`_
 * `v1.6.0 <http://alkaline-ml.com/pmdarima/1.6.0>`_
 * `v1.5.3 <http://alkaline-ml.com/pmdarima/1.5.3>`_

--- a/doc/no-successful-model.rst
+++ b/doc/no-successful-model.rst
@@ -10,7 +10,7 @@ For certain time series, the search may return no viable models::
       File "<stdin>", line 1, in <module>
         "Could not successfully fit a viable ARIMA model "
     ValueError: Could not successfully fit a viable ARIMA model to input data using the stepwise algorithm.
-    See http://alkaline-ml.com/pmdarima/no-successful-model.htmlfor more information on why this can happen.
+    See http://alkaline-ml.com/pmdarima/no-successful-model.html for more information on why this can happen.
 
 
 This can happen for a number of reasons:

--- a/doc/no-successful-model.rst
+++ b/doc/no-successful-model.rst
@@ -1,0 +1,29 @@
+.. _no_successful_model:
+
+===================================
+When no viable models can be found
+===================================
+
+For certain time series, the search may return no viable models::
+
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+        "Could not successfully fit a viable ARIMA model "
+    ValueError: Could not successfully fit a viable ARIMA model to input data using the stepwise algorithm.
+    See http://alkaline-ml.com/pmdarima/no-successful-model.htmlfor more information on why this can happen.
+
+
+This can happen for a number of reasons:
+
+* Most commonly, the roots of your model may be nearly non-invertible, meaning the inverted roots
+  lie too close to the unit circle. Here's a good `blog post <https://robjhyndman.com/hyndsight/arma-roots/>`_
+  on the subject. Make sure ``trace`` is truthy in order to see these warnings when fitting your model.
+
+* Sometimes, your data may not be stationary and can raise errors from statsmodels when fitting. In this case,
+  the stepwise algorithm will filter out problem model fits. This can arise in a number of situations, ranging
+  from non-stationarity to actual code errors. Setting ``error_action='trace'`` will log the stacktraces of
+  any errors encountered during the search.
+
+Make sure to set ``trace`` to at least 1 in order to see the search progress, and to a value >1 to see the
+maximum trace logging available. If you still cannot diagnose why you are getting this error message, consider
+:ref:`filing_bugs`.

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -24,6 +24,7 @@ contribute you'll need to be able to build from source.
    serialization.rst
    refreshing.rst
    tips_and_tricks.rst
+   no-successful-model.rst
    modules/datasets.rst
    usecases.rst
    contributing.rst

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,9 @@ v0.8.1) will document the latest features.
 * Fix issue `#351 <https://github.com/alkaline-ml/pmdarima/issues/351>`_ where a large
   value of ``m`` could prevent the seasonality test from completing.
 
+* Fix issue `#354 <https://github.com/alkaline-ml/pmdarima/issues/354>`_ where models with
+  near non-invertible roots could still be considered as candidate best-fits.
+
 
 `v1.6.1 <http://alkaline-ml.com/pmdarima/1.6.1/>`_
 --------------------------------------------------

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -367,9 +367,6 @@ class _StepwiseFitWrapper:
 
             # TODO: if (allowdrift || allowmean)
 
-        if not self.bestfit:
-            warnings.warn("No viable models found")
-
         # check if the search has been ended after max_steps
         if self.exec_context.max_steps is not None \
                 and self.k >= self.exec_context.max_steps:
@@ -377,6 +374,9 @@ class _StepwiseFitWrapper:
                           'of tries to find the best fit model')
 
         # TODO: if (approximation && !is.null(bestfit$arma))
+
+        if not self.bestfit:
+            warnings.warn("No viable models found")
 
         return _sort_and_filter_fits(self.results_dict, self.ic_dict)
 
@@ -396,7 +396,7 @@ def _sort_and_filter_fits(results_dict, ic_dict):
         raise ValueError(
             "Could not successfully fit a viable ARIMA model "
             "to input data using the stepwise algorithm.\nSee "
-            "http://alkaline-ml.com/pmdarima/no-successful-model.html"
+            "http://alkaline-ml.com/pmdarima/no-successful-model.html "
             "for more information on why this can happen."
         )
 

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -725,6 +725,7 @@ class ARIMA(BaseARIMA):
                           "behavior."
                           % (modl_version, this_version), UserWarning)
 
+    # TODO: get rid of this
     def _clear_cached_state(self):
         # THIS IS A LEGACY METHOD USED PRE-v0.8.0
         if _uses_legacy_pickling(self):

--- a/pmdarima/arima/tests/test_auto_solvers.py
+++ b/pmdarima/arima/tests/test_auto_solvers.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from pmdarima.arima import _auto_solvers as solvers
+from pmdarima.compat.pytest import pytest_error_str
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    'results_dict,ic_dict,expected', [
+
+        # No nones, no overlap in IC
+        pytest.param(
+            {'foo_key': 'foo', 'bar_key': 'bar', 'baz_key': 'baz'},
+            {'foo_key': 1.0, 'bar_key': 3.0, 'baz_key': 2.0},
+            ['foo', 'baz', 'bar'],
+        ),
+
+        # we filter out Nones
+        pytest.param(
+            {'foo_key': 'foo', 'bar_key': 'bar', 'baz_key': None},
+            {'foo_key': 1.0, 'bar_key': 3.0, 'baz_key': np.inf},
+            ['foo', 'bar'],
+        ),
+
+    ]
+)
+def test_sort_and_filter_valid(results_dict, ic_dict, expected):
+    actual = solvers._sort_and_filter_fits(results_dict, ic_dict)
+    assert tuple(expected) == tuple(actual), \
+        "\nExpected: %r" \
+        "\nActual: %r" \
+        % (expected, actual)
+
+
+def test_sort_and_filter_error():
+    results_dict = {'foo_key': None, 'bar_key': None, 'baz_key': None}
+    ic_dict = {'foo_key': np.inf, 'bar_key': np.inf, 'baz_key': np.inf}
+
+    with pytest.raises(ValueError) as ve:
+        solvers._sort_and_filter_fits(results_dict, ic_dict)
+    assert "no-successful-model" in pytest_error_str(ve)


### PR DESCRIPTION

# Description

Issue #354 pointed out a few corner cases where models with near non-invertable roots could still be considered as candidate models. This PR addresses those cases by filtering them from the returned stepwise search candidates.

Fixes #354 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change

# How Has This Been Tested?

- [X] Test the new `_sort_and_filter` method
- [X] All existing tests still pass
- [ ] (TODO) Mock corner cases pointed out in the issue and assert they no longer return bad model candidates

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
