### PR TITLE
[MRG+1] Remove legacy pickling behavior

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,9 @@ v0.8.1) will document the latest features.
 * Fix issue `#354 <https://github.com/alkaline-ml/pmdarima/issues/354>`_ where models with
   near non-invertible roots could still be considered as candidate best-fits.
 
+* Remove legacy pickling behavior that separates the statsmodels object from the pmdarima
+  object. This breaks backwards compatibility with versions pre-1.2.0.
+
 
 `v1.6.1 <http://alkaline-ml.com/pmdarima/1.6.1/>`_
 --------------------------------------------------

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -601,10 +601,6 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         # do the step-through...
         sorted_res = stepwise_wrapper.solve_stepwise()
 
-    # TODO: this will go away in the near future
-    for model in sorted_res:
-        model._clear_cached_state()
-
     return _return_wrapper(sorted_res, return_valid_fits, start, trace)
 
 

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -966,16 +966,17 @@ def test_to_dict_is_accurate():
 def test_serialization_methods_equal():
     arima = ARIMA(order=(0, 0, 0), suppress_warnings=True).fit(y)
 
-    with tempfile.NamedTemporaryFile() as tmp_pkl1:
-        joblib.dump(arima, tmp_pkl1.name)
-        loaded = joblib.load(tmp_pkl1.name)
+    with tempfile.TemporaryDirectory() as dirname:
+        joblib_path = os.path.join(dirname, "joblib.pkl")
+        joblib.dump(arima, joblib_path)
+        loaded = joblib.load(joblib_path)
         joblib_preds = loaded.predict()
 
-    with tempfile.NamedTemporaryFile() as tmp_pkl2:
-        with open(tmp_pkl2.name, 'wb') as p:
+        pickle_path = os.path.join(dirname, "pickle.pkl")
+        with open(pickle_path, 'wb') as p:
             pickle.dump(arima, p)
 
-        with open(tmp_pkl2.name, 'rb') as p:
+        with open(pickle_path, 'rb') as p:
             loaded = pickle.load(p)
         pickle_preds = loaded.predict()
 

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
+import pandas as pd
+
 from pmdarima.arima import ARIMA, auto_arima, AutoARIMA
-from pmdarima.arima.arima import VALID_SCORING, _uses_legacy_pickling
+from pmdarima.arima.arima import VALID_SCORING
 from pmdarima.arima.auto import _post_ppc_arima
 from pmdarima.arima.utils import nsdiffs
 from pmdarima.arima.warnings import ModelFitWarning
@@ -10,20 +13,18 @@ from pmdarima.datasets import load_lynx, load_wineind, load_heartrate, \
     load_austres
 from pmdarima.utils import get_callable
 
-import numpy as np
+from os.path import abspath, dirname
+from numpy.random import RandomState
 from numpy.testing import assert_array_almost_equal, assert_almost_equal, \
     assert_allclose
-from numpy.random import RandomState
+from statsmodels import api as sm
 
 import joblib
-from statsmodels import api as sm
-import pandas as pd
-
+import os
 import pickle
 import pytest
+import tempfile
 import time
-import os
-from os.path import abspath, dirname
 
 
 # initialize the random state
@@ -962,47 +963,23 @@ def test_to_dict_is_accurate():
     assert_almost_equal(actual['params'], expected['params'], decimal=3)
 
 
-def test_new_serialization():
+def test_serialization_methods_equal():
     arima = ARIMA(order=(0, 0, 0), suppress_warnings=True).fit(y)
 
-    # Serialize it, show there is no tmp_loc_
-    pkl_file = "file.pkl"
-    new_loc = "ts_wrapper.pkl"
-    try:
-        joblib.dump(arima, pkl_file)
+    with tempfile.NamedTemporaryFile() as tmp_pkl1:
+        joblib.dump(arima, tmp_pkl1.name)
+        loaded = joblib.load(tmp_pkl1.name)
+        joblib_preds = loaded.predict()
 
-        # Assert it does NOT use the old-style pickling
-        assert not _uses_legacy_pickling(arima)
-        loaded = joblib.load(pkl_file)
-        assert not _uses_legacy_pickling(loaded)
-        preds = loaded.predict()
-        os.unlink(pkl_file)
+    with tempfile.NamedTemporaryFile() as tmp_pkl2:
+        with open(tmp_pkl2.name, 'wb') as p:
+            pickle.dump(arima, p)
 
-        # Now save out the arima_res_ piece separately, and show we can load
-        # it from the legacy method
-        arima.summary()
-        arima.arima_res_.save(fname=new_loc)
-        arima.tmp_pkl_ = new_loc
+        with open(tmp_pkl2.name, 'rb') as p:
+            loaded = pickle.load(p)
+        pickle_preds = loaded.predict()
 
-        assert _uses_legacy_pickling(arima)
-
-        # Save/load it and show it works
-        joblib.dump(arima, pkl_file)
-        loaded2 = joblib.load(pkl_file)
-        assert_array_almost_equal(loaded2.predict(), preds)
-
-        # De-cache
-        arima._clear_cached_state()
-        assert not os.path.exists(new_loc)
-
-        # Show we get an OSError now
-        with pytest.raises(OSError) as ose:
-            joblib.load(pkl_file)
-        assert "Does it still" in pytest_error_str(ose), ose
-
-    finally:
-        _unlink_if_exists(pkl_file)
-        _unlink_if_exists(new_loc)
+    assert_array_almost_equal(joblib_preds, pickle_preds)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

# Description

Removes old (pre-1.2.0) behavior that split the statsmodels object out from the pmdarima object when serializing. This breaks backwards compatibility with old versions, but it was undesired, buggy behavior anyways. If a model was moved to another machine after serializing, it was un-loadable.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change

# How Has This Been Tested?

Tests of serialization have been updated, all other tests pass.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
