### PR TITLE
[MRG+2] support inverse_transformer when return_conf_int=True

### DIFF
--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -450,17 +450,18 @@ class Pipeline(BaseEstimator):
         conf_ints = None
         if return_conf_int:
             y_pred, conf_ints = y_pred
-            Xt_lower_bound, Xt_upper_bound = Xt, Xt
 
         # step through transformers in the reverse order
         for name, transformer in self.steps_[::-1]:
             if isinstance(transformer, BaseEndogTransformer):
                 y_pred, Xt = transformer.inverse_transform(y_pred, Xt)
                 if return_conf_int:
-                    conf_ints[:, 0], Xt_lower_bound = transformer.inverse_transform(
-                        conf_ints[:, 0], Xt_lower_bound)
-                    conf_ints[:, 1], Xt_upper_bound = transformer.inverse_transform(
-                        conf_ints[:, 1], Xt_upper_bound)
+                    # inverse transform of Xt is irrelevant to y
+                    # so only transform it once
+                    conf_ints[:, 0], _ = transformer.inverse_transform(
+                        conf_ints[:, 0], Xt)
+                    conf_ints[:, 1], _ = transformer.inverse_transform(
+                        conf_ints[:, 1], Xt)
 
         if return_conf_int:
             return y_pred, conf_ints

--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -77,6 +77,7 @@ class Pipeline(BaseEstimator):
                                         transparams=True, trend=None,
                                         with_intercept=True))])
     """
+
     def __init__(self, steps):
         self.steps = steps
         self._validate_steps()
@@ -456,8 +457,10 @@ class Pipeline(BaseEstimator):
             if isinstance(transformer, BaseEndogTransformer):
                 y_pred, Xt = transformer.inverse_transform(y_pred, Xt)
                 if return_conf_int:
-                    conf_ints[:, 0], Xt_lower_bound = transformer.inverse_transform(conf_ints[:, 0], Xt_lower_bound)
-                    conf_ints[:, 1], Xt_upper_bound = transformer.inverse_transform(conf_ints[:, 1], Xt_upper_bound)
+                    conf_ints[:, 0], Xt_lower_bound = transformer.inverse_transform(
+                        conf_ints[:, 0], Xt_lower_bound)
+                    conf_ints[:, 1], Xt_upper_bound = transformer.inverse_transform(
+                        conf_ints[:, 1], Xt_upper_bound)
 
         if return_conf_int:
             return y_pred, conf_ints

--- a/pmdarima/tests/test_pipeline.py
+++ b/pmdarima/tests/test_pipeline.py
@@ -203,6 +203,9 @@ def test_pipeline_predict_inverse_transform(pipeline, exog, inverse_transform,
 
     if return_conf_ints:
         assert isinstance(predictions, tuple) and len(predictions) == 2
+        y_pred, conf_ints = predictions
+        assert conf_ints.shape[1] == 2
+        assert np.all((conf_ints[:, 0] <= y_pred) & (y_pred <= conf_ints[:, 1]))
 
     # now in sample
     in_sample = pipeline.predict_in_sample(
@@ -212,6 +215,9 @@ def test_pipeline_predict_inverse_transform(pipeline, exog, inverse_transform,
 
     if return_conf_ints:
         assert isinstance(in_sample, tuple) and len(in_sample) == 2
+        y_pred, conf_ints = predictions
+        assert conf_ints.shape[1] == 2
+        assert np.all((conf_ints[:, 0] <= y_pred) & (y_pred <= conf_ints[:, 1]))
 
 
 def test_deprecation_warning():

--- a/pmdarima/tests/test_pipeline.py
+++ b/pmdarima/tests/test_pipeline.py
@@ -205,7 +205,9 @@ def test_pipeline_predict_inverse_transform(pipeline, exog, inverse_transform,
         assert isinstance(predictions, tuple) and len(predictions) == 2
         y_pred, conf_ints = predictions
         assert conf_ints.shape[1] == 2
-        assert np.all((conf_ints[:, 0] <= y_pred) & (y_pred <= conf_ints[:, 1]))
+        assert np.all(
+            (conf_ints[:, 0] <= y_pred) & (y_pred <= conf_ints[:, 1])
+        )
 
     # now in sample
     in_sample = pipeline.predict_in_sample(
@@ -217,7 +219,9 @@ def test_pipeline_predict_inverse_transform(pipeline, exog, inverse_transform,
         assert isinstance(in_sample, tuple) and len(in_sample) == 2
         y_pred, conf_ints = predictions
         assert conf_ints.shape[1] == 2
-        assert np.all((conf_ints[:, 0] <= y_pred) & (y_pred <= conf_ints[:, 1]))
+        assert np.all(
+            (conf_ints[:, 0] <= y_pred) & (y_pred <= conf_ints[:, 1])
+        )
 
 
 def test_deprecation_warning():


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Currently, if there's an endogenous transformer in the pipeline and try to run `pipeline.predict(*, return_conf_int=True)`, pipeline would not do inverse transform. This pull request tries to fix this. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Current tests cover this functionality. 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
