### PR TITLE
[DOC] Add a migration guide for pyramid -> pmdarima

### DIFF
--- a/doc/migration-guide.rst
+++ b/doc/migration-guide.rst
@@ -1,0 +1,31 @@
+.. _migration:
+
+============================
+``pmdarima`` Migration guide
+============================
+
+In `issue #34 <https://github.com/alkaline-ml/pmdarima/issues/34>`_ we made the
+decision to migrate from the ``pyramid-arima`` namespace to the ``pmdarima``
+namespace to avoid collisions with the web framework named ``pyramid``.
+
+Migration is simple:
+
+.. code-block:: bash
+
+    $ pip install pmdarima
+
+Rather that importing functions and modules from the ``pyramid`` package, simply
+import from ``pmdarima`` instead:
+
+.. code-block:: python
+
+    from pmdarima.arima import auto_arima
+
+Or just import it as a namespace:
+
+.. code-block:: python
+
+    import pmdarima as pm
+    my_model = pm.auto_arima(my_timeseries)
+
+For further installation instructions, check out the :ref:`setup` and :ref:`quickstart` guides.

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -8,7 +8,8 @@ User Guide
 
 The following guides cover how to get started with a pmdarima distribution. The
 easiest solution is simply installing from PyPi, but if you'd like to
-contribute you'll need to be able to build from source.
+contribute you'll need to be able to build from source, as laid out in the
+:ref:`setup` section.
 
 .. raw:: html
 

--- a/pmdarima/arima/_validation.py
+++ b/pmdarima/arima/_validation.py
@@ -53,8 +53,10 @@ def check_m(m, seasonal):
     if (m < 1 and seasonal) or m < 0:
         raise ValueError('m must be a positive integer (> 0)')
 
-    if m > 0 and not seasonal:
-        warnings.warn("m (%i) set for non-seasonal fit. Setting to 0" % m)
+    if not seasonal:
+        # default m is 1, so if it's the default, don't warn
+        if m > 1:
+            warnings.warn("m (%i) set for non-seasonal fit. Setting to 0" % m)
         m = 0
 
     return m

--- a/pmdarima/arima/tests/test_validation.py
+++ b/pmdarima/arima/tests/test_validation.py
@@ -67,9 +67,10 @@ def test_check_kwargs(kwargs, expected):
         pytest.param(12, True, False, False, 12),
         pytest.param(1, True, False, False, 1),
         pytest.param(0, False, False, False, 0),
+        pytest.param(1, False, False, False, 0),
 
         # unhappy path :-(
-        pytest.param(1, False, False, True, 0),
+        pytest.param(2, False, False, True, 0),
         pytest.param(0, True, True, False, None),
         pytest.param(-1, False, True, False, None),
 


### PR DESCRIPTION

# Description

We still get issues asking about installing `pyramid-arima`, and despite the warning message the last version issues on install, people land here. I want to make the old doc link resolve to a migration guide rather than redirecting to the current home page.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change
