### PR TITLE
[WIP] Add an option to return raw predictions for different horizons when using cross_val_predict

### DIFF
--- a/pmdarima/model_selection/_validation.py
+++ b/pmdarima/model_selection/_validation.py
@@ -220,6 +220,7 @@ def cross_validate(estimator,
     return ret
 
 
+<<<<<<< HEAD
 def cross_val_predict(estimator,
                       y,
                       X=None,
@@ -227,6 +228,10 @@ def cross_val_predict(estimator,
                       verbose=0,
                       averaging="mean",
                       **kwargs):  # TODO: remove kwargs
+=======
+def cross_val_predict(estimator, y, exogenous=None, cv=None, verbose=0,
+                      averaging="mean", return_forecast_horizons=False):
+>>>>>>> first iteration
     """Generate cross-validated estimates for each input data point
 
     Parameters
@@ -266,6 +271,24 @@ def cross_val_predict(estimator,
 
         We then average each time step's forecasts to end up with our final
         prediction results.
+
+    return_forecast_horizons: bool (default=False)
+        If True, raw predictions are returned in a y x h matrix. E.g. if h=3,
+        and step=1 then:
+
+            nan nan nan # training samples
+            nan nan nan
+            nan nan nan
+            nan nan nan
+            1   4   2   # test samples
+            2   5   7
+            8   9   1
+            nan nan nan
+            nan nan nan
+
+        First column contains all one-step-ahead-predictions, second column all
+        two-step-ahead-predictions and so forth. Further metrics can then be
+        calculated as desired.
 
     Examples
     --------
@@ -326,6 +349,14 @@ def cross_val_predict(estimator,
     pred_matrix = np.ones((y.shape[0], len(prediction_blocks))) * np.nan
     for i, (pred_block, test_indices) in enumerate(prediction_blocks):
         pred_matrix[test_indices, i] = pred_block
+
+    if return_forecast_horizons:
+        pred_matrix = np.ones((y.shape[0], cv.horizon)) * np.nan
+        prediction_blocks = np.array(prediction_blocks)
+        predictions = prediction_blocks[:,0,:]
+        indices = prediction_blocks[:,1,:][:,0].astype(int) - 1
+        pred_matrix[indices] = predictions
+        return pred_matrix
 
     # from there, we need to apply nanmean (or some other metric) along rows
     # to agree on a forecast for a sample.


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Currently cross_val_predict averages predictions of overlapping folds. Averaging over these results is often not the desired approach. Instead we often want to evaluate the predictive accuracy on different horizons. Following matrix as an output would enable that:

| DateTime    | t+1      | t+2     | t+3    | t+h   |
| --------    | ------ | ----- | ---- | --- |
| 01-01-1917  | 20     | 25    | 18   | p1  |
| 02-01-1917  | 13     | 17    | 29   | p2  |
| 03-01-1917  | 19     | 14    | 18   | p3  |
| ...          |   |   |   |   |

Current solution feels quite hacky, please let me know if you have ideas for a more elegant approach.

Fixes #364 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation change

# How Has This Been Tested?

Currently only tested manually on JupyterLab.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
