### PR TITLE
[RFC] exogenous -> X

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,8 +9,8 @@ pmdarima: ARIMA estimators for Python
 
 ``pmdarima`` brings R's beloved ``auto.arima`` to Python, making an even stronger
 case for why you don't need R for data science. ``pmdarima`` is 100% Python + Cython
-and does not leverage any R code, and implements a single, easy-to-use
-scikit-learn-esque estimator.
+and does not leverage any R code, but is implemented in a powerful, yet easy-to-use set of
+functions & classes that will be familiar to scikit-learn users.
 
 .. toctree::
    :maxdepth: 2
@@ -20,6 +20,7 @@ scikit-learn-esque estimator.
    Examples <./auto_examples/index.rst>
    User Guide <./user_guide.rst>
    What's New? <./whats_new.rst>
+   RFCs <./rfc/index.rst>
 
 
 .. raw:: html

--- a/doc/rfc/372-exog-to-x.rst
+++ b/doc/rfc/372-exog-to-x.rst
@@ -1,0 +1,53 @@
+.. _exog_to_X:
+
+===========================
+RFC: ``exogenous`` -> ``X``
+===========================
+
+This RFC proposes the renaming of the ``exogenous`` arg to ``X``. While this would
+impact the public API, we would allow the current ``exogenous`` argument to persist
+for several minor release cycles with a deprecation warning before completely removing it
+in the next major release (2.0).
+
+Why?
+----
+
+* **It's typo-prone**. We've received several issues lately with people asking why the ``exogenous``
+  argument was not doing anything. Upon close inspection, it was evident they were misspelling the
+  arg as "exogeneous", and the presence of ``**kwargs`` in the function signature allowed
+  the argument through without raising a ``TypeError``.
+
+* **It's clunky**. Typing ``exogenous`` when other APIs have simplified this to the ubiquitous
+  ``X`` used in other scikit-style packages (scikit-learn, scikit-image, sktime) seems like
+  a slightly annoying, arbitrary difference in signature definitions that keeps us from
+  matching the signatures of other similar packages.
+
+* **It can be confusing**. Not all of our user base is familiar with the classical statistics
+  terminology and may not realize what this argument permits them. Conversely, nearly all
+  users are familiar with the idea of what ``X`` allows them.
+
+How?
+----
+
+For a while, we'd allow the ``exogenous`` argument to be passed in ``**kwargs``, and would simply
+warn if it were present. For example:
+
+.. code-block:: python
+
+    def fit(self, y, X=None, **kwargs):
+        if X is None:
+            X = kwargs.pop("exogenous", None)
+            if X is not None:
+                warnings.warn("`exogenous` is deprecated and will raise an error "
+                              "in version 2.0 - Use the `X` arg instead",
+                              DeprecationWarning)
+
+This would ensure backwards compatibility for several minor release cycles before the
+change was made, and would give sufficient time to users to switch over to the new naming scheme.
+
+Precedent
+---------
+
+Scikit-learn has made similar package naming decisions in the name of package consistency and ubiquity,
+notably in migrating the ``cross_validation`` namespace to the ``model_selection`` namespace in version
+0.18. This was preceded by several minor releases that warned on imports.

--- a/doc/rfc/index.rst
+++ b/doc/rfc/index.rst
@@ -1,0 +1,17 @@
+.. _rfc:
+
+=============
+pmdarima RFCs
+=============
+
+An RFC, or "request for comments," is a common practice in open source packages, and
+allows users and contributors to weigh in on a proposal that will fundamentally alter
+the public API (usually encompassing breaking changes or design decisions). All ``pmdarima``
+RFCs will be included for future users of the package to read through so that decision-making
+is transparent and makes sense to all users.
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   Renaming the ``exogenous`` argument <./372-exog-to-x-rst.rst>

--- a/doc/rfc/index.rst
+++ b/doc/rfc/index.rst
@@ -14,4 +14,4 @@ is transparent and makes sense to all users.
    :maxdepth: 2
    :hidden:
 
-   Renaming the ``exogenous`` argument <./372-exog-to-x-rst.rst>
+   Renaming the ``exogenous`` argument <./372-exog-to-x.rst>


### PR DESCRIPTION
This is an RFC proposing we switch the use of the `exogenous` arg to `X` for consistency with similar packages, and easy user onboarding. The reasons and approach are laid out in the `.rst` file in this PR.

Please leave comments, and reactions to this PR (👍  / 👎 ). I won't merge it for at least a week, and only if we decide to move forward with it.

(Inviting comments from some previous contributors @tuomijal @skyetim @mohitmunjal @christopher-siewert)