### PR TITLE
[MRG] Pin statsmodels to <0.12

### DIFF
--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -3,7 +3,7 @@ scipy>=1.3.2
 cython>=0.29,<0.29.18
 scikit-learn>=0.22
 pandas>=0.19
-statsmodels>=0.11
+statsmodels>=0.11,<0.12
 patsy
 pytest
 pytest-mpl

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ numpy>=1.17.3
 pandas>=0.19
 scikit-learn>=0.22
 scipy>=1.3.2
-statsmodels>=0.11
+statsmodels>=0.11,<0.12
 urllib3


### PR DESCRIPTION

# Description

This PR is a temporary fix with the release of statmodels 0.12 so our package will still work

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] CI/CD passes

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
