### PR TITLE
[HOTFIX] Pin setuptools

### DIFF
--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -8,7 +8,7 @@ patsy
 pytest
 pytest-mpl
 pytest-benchmark
-setuptools>=38.6.0
+setuptools>=38.6.0,<50.0.0
 wheel
 twine>=1.13.0
 readme_renderer

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn>=0.22
 scipy>=1.3.2
 statsmodels>=0.11,<0.12
 urllib3
+setuptools<50.0.0


### PR DESCRIPTION
Setuptools released 50.0.0, which is breaking our build. This pins to setuptools < 50.0.0