### PR TITLE
[MAINT] Do not run CI/CD on push to branch

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,7 +3,7 @@ name: Mac and Windows Builds
 on:
   push:
     branches:
-      - '*'
+      - 'master'
     tags:
       - '*'
 

--- a/.github/workflows/test_tagging.yml
+++ b/.github/workflows/test_tagging.yml
@@ -3,7 +3,7 @@ name: Test VERSION tagging
 on:
   push:
     branches:
-      - '*'
+      - 'master'
 
   pull_request:
     branches:


### PR DESCRIPTION
Remove push-to-branch trigger for GitHub Actions