### PR TITLE
[MRG+1] Remove python 3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ commands:
     steps:
       - checkout
       - run: make develop
+      - run: make testing-requirements
       - run: make test-unit
       - run: codecov || echo "codecov upload failed"
 
@@ -66,13 +67,6 @@ commands:
             ./build_tools/circle/deploy.sh
 
 jobs:
-
-  cpython35:
-    docker:
-      - image: python:3.5
-    working_directory: ~/pmdarima
-    steps:
-    - make-unit-test
 
   cpython36:
     docker:
@@ -116,6 +110,7 @@ jobs:
     working_directory: ~/pmdarima
     steps:
     - checkout
+    - run: make lint-requirements
     - run: make test-lint
 
   # Test env vars from tags produce VERSION file
@@ -153,15 +148,6 @@ jobs:
   # capacity, so should be run on machines
   #
   # ############################################
-  deploy-cpython35-whl:
-    machine:
-      image: circleci/classic:latest
-    working_directory: ~/pmdarima
-    steps:
-      - checkout
-      - build-whl-file:
-          pythonversion: "3.5"
-      - deploy-to-pypi
 
   deploy-cpython36-whl:
     machine:
@@ -221,8 +207,6 @@ workflows:
             filters: *test-only-filters
 
         # run on test and tag
-        - cpython35:
-            filters: *test-filters
         - cpython36:
             filters: *test-filters
         - cpython37:
@@ -237,7 +221,6 @@ workflows:
             filters: *test-filters
         - testing-passed:
             requires:
-                - cpython35
                 - cpython36
                 - cpython37
                 - cpython38
@@ -252,11 +235,6 @@ workflows:
                 - build-doc
                 - testing-passed
             filters: *test-filters
-
-        - deploy-cpython35-whl:
-            filters: *deploy-filters
-            requires:
-                - deploy-doc
 
         - deploy-cpython36-whl:
             filters: *deploy-filters

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ['3.5', '3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8']
         architecture: ['x86', 'x64']
         exclude:
           # Don't build 32-bit on Mac

--- a/Makefile
+++ b/Makefile
@@ -51,22 +51,19 @@ develop: version
 install: version
 	$(PYTHON) setup.py install
 
-test-requirements:
-	$(PYTHON) -m pip install pytest flake8 matplotlib pytest-mpl pytest-benchmark
+lint-requirements:
+	$(PYTHON) -m pip install flake8
 
-coverage-dependencies:
-	$(PYTHON) -m pip install coverage pytest-cov codecov
+testing-requirements:
+	$(PYTHON) -m pip install pytest flake8 matplotlib pytest-mpl pytest-benchmark coverage pytest-cov codecov
 
-test-lint: test-requirements
+test-lint:
 	$(PYTHON) -m flake8 pmdarima --filename='*.py' --ignore F401,F403,W293,W504
 
-test-unit: test-requirements coverage-dependencies
+test-unit:
 	$(PYTHON) -m pytest -v --durations=20 --cov-config .coveragerc --cov pmdarima -p no:logging --benchmark-skip
 
-test-benchmark: test-requirements coverage-dependencies
-	$(PYTHON) -m pytest -v --durations=12 --cov-config .coveragerc --cov pmdarima -p no:logging --benchmark-min-rounds=5 --benchmark-min-time=1 --benchmark-only
-
-test: develop test-unit test-lint
+test: test-unit test-lint
 	# Coverage creates all these random little artifacts we don't want
 	rm .coverage.* || echo "No coverage artifacts to remove"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CircleCI](https://circleci.com/gh/alkaline-ml/pmdarima.svg?style=svg)](https://circleci.com/gh/alkaline-ml/pmdarima)
 [![Github Actions Status](https://github.com/alkaline-ml/pmdarima/workflows/Mac%20and%20Windows%20Builds/badge.svg?branch=master)](https://github.com/alkaline-ml/pmdarima/actions?query=workflow%3A%22Mac+and+Windows+Builds%22+branch%3Amaster)
 [![codecov](https://codecov.io/gh/alkaline-ml/pmdarima/branch/master/graph/badge.svg)](https://codecov.io/gh/alkaline-ml/pmdarima)
-![Supported versions](https://img.shields.io/badge/python-3.5+-blue.svg)
+![Supported versions](https://img.shields.io/badge/python-3.6+-blue.svg)
 ![Downloads](https://img.shields.io/badge/dynamic/json?color=blue&label=downloads&query=%24.total&url=https%3A%2F%2Fstore.zapier.com%2Fapi%2Frecords%3Fsecret%3D1e061b29db6c4f15af01103d403b0237)
 ![Downloads/Week](https://img.shields.io/badge/dynamic/json?color=blue&label=downloads%2Fweek&query=%24.weekly&url=https%3A%2F%2Fstore.zapier.com%2Fapi%2Frecords%3Fsecret%3D1e061b29db6c4f15af01103d403b0237)
 
@@ -103,7 +103,7 @@ with open('model.pkl', 'rb') as pkl:
 
 ### Availability
 
-`pmdarima` is available on PyPi in pre-built Wheel files for Python 3.5+ for the following platforms:
+`pmdarima` is available on PyPi in pre-built Wheel files for Python 3.6+ for the following platforms:
 
 * Mac (64-bit)
 * Linux (64-bit manylinux)

--- a/build_tools/circle/build_manylinux_wheel.sh
+++ b/build_tools/circle/build_manylinux_wheel.sh
@@ -10,7 +10,7 @@ PIP="/opt/python/${PYTHON_VERSION}/bin/pip"
 # We have to use wheel < 0.32 since they inexplicably removed the open_for_csv
 # function from the package after 0.31.1 and it fails for Python 3.6?!
 ${PIP} install --upgrade pip wheel==0.31.1
-${PIP} install --upgrade setuptools<50.0.0
+${PIP} install --upgrade "setuptools<50.0.0"
 ${PIP} install --upgrade cython
 ${PIP} install --upgrade numpy
 

--- a/build_tools/circle/build_wheel.sh
+++ b/build_tools/circle/build_wheel.sh
@@ -21,7 +21,7 @@ function build_wheel {
 	       min='${pyver}'.split('.')[1], \
 	       ucs='${ucs_tag}'))")
 
-    DOCKER_CONTAINER_NAME="wheel_builder"
+    DOCKER_CONTAINER_NAME=wheel_builder_$(uuidgen)
 
     # Pin this image because wheel versions in later tags conflict
     ML_IMAGE="quay.io/pypa/manylinux1_${arch}:2020-01-31-d8fa357"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,6 +48,8 @@ Other versions
 
 Documentation for other release versions of ``pmdarima``:
 
+* `v1.8.0 <http://alkaline-ml.com/pmdarima/1.8.0>`_
+* `v1.7.1 <http://alkaline-ml.com/pmdarima/1.7.1>`_
 * `v1.7.0 <http://alkaline-ml.com/pmdarima/1.7.0>`_
 * `v1.6.1 <http://alkaline-ml.com/pmdarima/1.6.1>`_
 * `v1.6.0 <http://alkaline-ml.com/pmdarima/1.6.0>`_

--- a/doc/usecases/stocks.rst
+++ b/doc/usecases/stocks.rst
@@ -21,9 +21,7 @@ To run this example, you'll need pmdarima version 1.5.2 or greater. If you're
 running this in a notebook, make sure to include ``%matplotlib inline``, or the plots
 will not show up under your cells!
 
-This example was also designed for Python 3.6+. If you're running python 3.5, simply
-remove the `F-string <https://www.python.org/dev/peps/pep-0498/>`_ print statements and
-it will work.
+Keep in mind you'll need Python 3.6+ to install ``pmdarima``.
 
 .. code-block:: python
 

--- a/doc/usecases/sun-spots.rst
+++ b/doc/usecases/sun-spots.rst
@@ -21,8 +21,7 @@ Here's what you'll need to run this example:
   * Matplotlib - It's not a hard requirement of the package itself, but you'll need it
     to run these examples (if you're running this in a notebook, make sure to include ``%matplotlib inline``)
 
-  * Python 3.6+. If you're running python 3.5, simply remove the `F-string <https://www.python.org/dev/peps/pep-0498/>`_
-    print statements and it will work.
+  * Python 3.6+
 
 
 Imports, data loading & splitting

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,6 +8,13 @@ As new releases of pmdarima are pushed out, the following list (introduced in
 v0.8.1) will document the latest features.
 
 
+`v1.8.0 <http://alkaline-ml.com/pmdarima/1.8.0/>`_
+--------------------------------------------------
+
+* Wheels are no longer built for ``pmdarima`` on Python <3.6, and backward-compatibility
+  is no longer guaranteed for older python versions.
+
+
 `v1.7.1 <http://alkaline-ml.com/pmdarima/1.7.1/>`_
 --------------------------------------------------
 


### PR DESCRIPTION
Python 3.5 is nearing its [end-of-life](https://endoflife.date/python). This PR removes all python 3.5 support, and cleans up various things in the `Makefile`