### PR TITLE
[MRG+1] Exogenous -> X

### DIFF
--- a/doc/rfc/index.rst
+++ b/doc/rfc/index.rst
@@ -14,4 +14,4 @@ is transparent and makes sense to all users.
    :maxdepth: 2
    :hidden:
 
-   Renaming the ``exogenous`` argument <./372-exog-to-x.rst>
+   Renaming the "exogenous" argument <./372-exog-to-x.rst>

--- a/examples/example_pipeline.py
+++ b/examples/example_pipeline.py
@@ -61,7 +61,7 @@ fig.tight_layout()
 
 # Visualize goodness of fit
 in_sample_preds, in_sample_confint = \
-    pipe.predict_in_sample(exogenous=None, return_conf_int=True)
+    pipe.predict_in_sample(X=None, return_conf_int=True)
 
 n_train = train.shape[0]
 

--- a/examples/preprocessing/example_date_featurizer.py
+++ b/examples/preprocessing/example_date_featurizer.py
@@ -45,14 +45,14 @@ n_diffs = arima.ndiffs(y_train, max_d=5)
 
 # Here's what the featurizer will create for us:
 date_feat = preprocessing.DateFeaturizer(
-    column_name="date",  # the name of the date feature in the exog matrix
+    column_name="date",  # the name of the date feature in the X matrix
     with_day_of_week=True,
     with_day_of_month=True)
 
 _, X_train_feats = date_feat.fit_transform(y_train, X_train)
-print("Head of generated exog features:\n%s" % repr(X_train_feats.head()))
+print("Head of generated X features:\n%s" % repr(X_train_feats.head()))
 
-# We can plug this exog featurizer into a pipeline:
+# We can plug this X featurizer into a pipeline:
 pipe = pipeline.Pipeline([
     ('date', date_feat),
     ('arima', arima.AutoARIMA(d=n_diffs,
@@ -65,7 +65,7 @@ pipe = pipeline.Pipeline([
 pipe.fit(y_train, X_train)
 
 # Plot our forecasts
-forecasts = pipe.predict(exogenous=X_test)
+forecasts = pipe.predict(X=X_test)
 
 fig = plt.figure(figsize=(16, 8))
 ax = fig.add_subplot(1, 1, 1)

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -418,7 +418,7 @@ def _fit_candidate_model(x,
                 with_intercept=with_intercept, **kwargs)
 
     try:
-        fit.fit(x, exogenous=xreg, **fit_params)
+        fit.fit(x, X=xreg, **fit_params)
 
     # for non-stationarity errors or singular matrices, return None
     except (LinAlgError, ValueError) as v:

--- a/pmdarima/arima/_doc.py
+++ b/pmdarima/arima/_doc.py
@@ -34,7 +34,7 @@ _AUTO_ARIMA_DOCSTR = \
     Khandakar (2008).
 
     Parameters
-    ----------{y}{exogenous}
+    ----------{y}{X}
     start_p : int, optional (default=2)
         The starting value of ``p``, the order (or number of time lags)
         of the auto-regressive ("AR") model. Must be a positive integer.

--- a/pmdarima/arima/_doc.py
+++ b/pmdarima/arima/_doc.py
@@ -275,7 +275,7 @@ _Y_DOCSTR = """
 """
 
 _EXOG_DOCSTR = """
-    exogenous : array-like, shape=[n_obs, n_vars], optional (default=None)
+    X : array-like, shape=[n_obs, n_vars], optional (default=None)
         An optional 2-d array of exogenous variables. If provided, these
         variables are used as additional features in the regression
         operation. This should not include a constant or trend. Note that

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -677,7 +677,7 @@ class ARIMA(BaseARIMA):
             arima_res=arima,
             start=arima.nobs,
             end=end,
-            exog=X,
+            X=X,
             alpha=alpha)
 
         if return_conf_int:

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -819,8 +819,10 @@ class ARIMA(BaseARIMA):
             n_exog, exog_dim = X.shape
 
             if X.shape[1] != k_exog:
-                raise ValueError("Dim mismatch in fit X (%i) and new "
-                                 "X (%i)" % (k_exog, exog_dim))
+                raise ValueError(
+                    f"Dim mismatch in fit `X` ({k_exog}) and new "
+                    f"`X` ({exog_dim})"
+                )
 
             # make sure the number of samples in X match the number
             # of samples in the endog

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -407,7 +407,7 @@ class ARIMA(BaseARIMA):
         # Set df_model attribute for SARIMAXResults object
         sm_compat.bind_df_model(fit, self.arima_res_)
 
-        # if the model is fit with an exogenous array, it must
+        # if the model is fit with an X array, it must
         # be predicted with one as well.
         self.fit_with_exog_ = X is not None
 
@@ -669,7 +669,7 @@ class ARIMA(BaseARIMA):
         if X is not None and X.shape[0] != n_periods:
             raise ValueError('X array dims (n_rows) != n_periods')
 
-        # f = self.arima_res_.forecast(steps=n_periods, exog=exogenous)
+        # f = self.arima_res_.forecast(steps=n_periods, exog=X)
         arima = self.arima_res_
         end = arima.nobs + n_periods - 1
 

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -283,7 +283,7 @@ class StepwiseContext(AbstractContext):
 
 
 def auto_arima(y,
-               exogenous=None,
+               X=None,
                start_p=2,
                d=None,
                start_q=2,
@@ -327,6 +327,9 @@ def auto_arima(y,
                **fit_args):
 
     # NOTE: Doc is assigned BELOW this function
+
+    # Temporary shim until we remove `exogenous` support completely
+    X, kwargs = pm_compat.get_X(X, **fit_args)
 
     # pop out the deprecated kwargs
     fit_args = _warn_for_deprecations(**fit_args)

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -26,6 +26,7 @@ from ._context import AbstractContext, ContextType
 from . import _auto_solvers as solvers
 from ..compat.numpy import DTYPE
 from ..compat import statsmodels as sm_compat
+from ..compat import pmdarima as pm_compat
 
 __all__ = [
     'auto_arima',
@@ -48,7 +49,7 @@ class AutoARIMA(BaseARIMA):
     # Don't add the y, exog, etc. here since they are used in 'fit'
     __doc__ = _doc._AUTO_ARIMA_DOCSTR.format(
         y="",
-        exogenous="",
+        X="",
         fit_args="",
         return_valid_fits="",
         sarimax_kwargs=_doc._KWARGS_DOCSTR)
@@ -146,11 +147,11 @@ class AutoARIMA(BaseARIMA):
         kwargs = _warn_for_deprecations(**kwargs)
         self.kwargs = kwargs
 
-    def fit(self, y, exogenous=None, **fit_args):
+    def fit(self, y, X=None, **fit_args):
         """Fit the auto-arima estimator
 
         Fit an AutoARIMA to a vector, ``y``, of observations with an
-        optional matrix of ``exogenous`` variables.
+        optional matrix of ``X`` variables.
 
         Parameters
         ----------
@@ -161,7 +162,7 @@ class AutoARIMA(BaseARIMA):
             one-dimensional array of floats, and should not contain any
             ``np.nan`` or ``np.inf`` values.
 
-        exogenous : array-like, shape=[n_obs, n_vars], optional (default=None)
+        X : array-like, shape=[n_obs, n_vars], optional (default=None)
             An optional 2-d array of exogenous variables. If provided, these
             variables are used as additional features in the regression
             operation. This should not include a constant or trend. Note that
@@ -172,50 +173,111 @@ class AutoARIMA(BaseARIMA):
             Any keyword arguments to pass to the auto-arima function.
         """
         sarimax_kwargs = {} if not self.kwargs else self.kwargs
+
+        # Temporary shim until we remove `exogenous` support completely
+        X, fit_kwargs = pm_compat.get_X(X, **fit_args)
         self.model_ = auto_arima(
-            y, exogenous=exogenous, start_p=self.start_p, d=self.d,
-            start_q=self.start_q, max_p=self.max_p, max_d=self.max_d,
-            max_q=self.max_q, start_P=self.start_P, D=self.D,
-            start_Q=self.start_Q, max_P=self.max_P, max_D=self.max_D,
-            max_Q=self.max_Q, max_order=self.max_order, m=self.m,
-            seasonal=self.seasonal, stationary=self.stationary,
+            y,
+            X=X,
+            start_p=self.start_p,
+            d=self.d,
+            start_q=self.start_q,
+            max_p=self.max_p,
+            max_d=self.max_d,
+            max_q=self.max_q,
+            start_P=self.start_P,
+            D=self.D,
+            start_Q=self.start_Q,
+            max_P=self.max_P,
+            max_D=self.max_D,
+            max_Q=self.max_Q,
+            max_order=self.max_order,
+            m=self.m,
+            seasonal=self.seasonal,
+            stationary=self.stationary,
             information_criterion=self.information_criterion,
-            alpha=self.alpha, test=self.test, seasonal_test=self.seasonal_test,
-            stepwise=self.stepwise, n_jobs=self.n_jobs,
-            start_params=self.start_params, trend=self.trend,
-            method=self.method, maxiter=self.maxiter,
+            alpha=self.alpha,
+            test=self.test,
+            seasonal_test=self.seasonal_test,
+            stepwise=self.stepwise,
+            n_jobs=self.n_jobs,
+            start_params=self.start_params,
+            trend=self.trend,
+            method=self.method,
+            maxiter=self.maxiter,
             offset_test_args=self.offset_test_args,
             seasonal_test_args=self.seasonal_test_args,
             suppress_warnings=self.suppress_warnings,
-            error_action=self.error_action, trace=self.trace,
-            random=self.random, random_state=self.random_state,
+            error_action=self.error_action,
+            trace=self.trace,
+            random=self.random,
+            random_state=self.random_state,
             n_fits=self.n_fits,
             return_valid_fits=False,  # only return ONE
-            out_of_sample_size=self.out_of_sample_size, scoring=self.scoring,
-            scoring_args=self.scoring_args, with_intercept=self.with_intercept,
-            sarimax_kwargs=sarimax_kwargs, **fit_args)
+            out_of_sample_size=self.out_of_sample_size,
+            scoring=self.scoring,
+            scoring_args=self.scoring_args,
+            with_intercept=self.with_intercept,
+            sarimax_kwargs=sarimax_kwargs,
+            **fit_args)
 
         return self
 
     @if_has_delegate("model_")
-    def predict_in_sample(self, exogenous=None, start=None,
-                          end=None, dynamic=False, return_conf_int=False,
-                          alpha=0.05, typ='levels'):
+    def predict_in_sample(self,
+                          X=None,
+                          start=None,
+                          end=None,
+                          dynamic=False,
+                          return_conf_int=False,
+                          alpha=0.05,
+                          typ='levels',
+                          **kwargs):  # TODO: remove kwargs when exog goes
+
+        # Temporary shim until we remove `exogenous` support completely
+        X, _ = pm_compat.get_X(X, **kwargs)
         return self.model_.predict_in_sample(
-            exogenous=exogenous, start=start, end=end, dynamic=dynamic,
-            return_conf_int=return_conf_int, alpha=alpha, typ=typ)
+            X=X,
+            start=start,
+            end=end,
+            dynamic=dynamic,
+            return_conf_int=return_conf_int,
+            alpha=alpha,
+            typ=typ,
+        )
 
     @if_has_delegate("model_")
-    def predict(self, n_periods=10, exogenous=None,
-                return_conf_int=False, alpha=0.05):
+    def predict(self,
+                n_periods=10,
+                X=None,
+                return_conf_int=False,
+                alpha=0.05,
+                **kwargs):  # TODO: remove kwargs when exog goes
+
+        # Temporary shim until we remove `exogenous` support completely
+        X, _ = pm_compat.get_X(X, **kwargs)
         return self.model_.predict(
-            n_periods=n_periods, exogenous=exogenous,
-            return_conf_int=return_conf_int, alpha=alpha)
+            n_periods=n_periods,
+            X=X,
+            return_conf_int=return_conf_int,
+            alpha=alpha,
+        )
 
     @if_has_delegate("model_")
-    def update(self, y, exogenous=None, maxiter=None, **kwargs):
+    def update(self,
+               y,
+               X=None,
+               maxiter=None,
+               **kwargs):
+
+        # Temporary shim until we remove `exogenous` support completely
+        X, kwargs = pm_compat.get_X(X, **kwargs)
         return self.model_.update(
-            y, exogenous=exogenous, maxiter=maxiter, **kwargs)
+            y,
+            X=X,
+            maxiter=maxiter,
+            **kwargs
+        )
 
     @if_has_delegate('model_')
     def summary(self):
@@ -329,7 +391,7 @@ def auto_arima(y,
     # NOTE: Doc is assigned BELOW this function
 
     # Temporary shim until we remove `exogenous` support completely
-    X, kwargs = pm_compat.get_X(X, **fit_args)
+    X, fit_args = pm_compat.get_X(X, **fit_args)
 
     # pop out the deprecated kwargs
     fit_args = _warn_for_deprecations(**fit_args)
@@ -404,7 +466,7 @@ def auto_arima(y,
             solvers._sort_and_filter_fits(
                 fit_partial(
                     y,
-                    xreg=exogenous,
+                    xreg=X,
                     order=(0, 0, 0),
                     seasonal_order=(0, 0, 0, 0),
                     with_intercept=val.auto_intercept(
@@ -445,9 +507,9 @@ def auto_arima(y,
 
     # TODO: check rank deficiency, check for constant Xs, regress if necessary
     xx = y.copy()
-    if exogenous is not None:
-        lm = LinearRegression().fit(exogenous, y)
-        xx = y - lm.predict(exogenous)
+    if X is not None:
+        lm = LinearRegression().fit(X, y)
+        xx = y - lm.predict(X)
 
     # choose the order of differencing
     # is the TS stationary?
@@ -462,8 +524,8 @@ def auto_arima(y,
         D = nsdiffs(xx, m=m, test=seasonal_test, max_D=max_D,
                     **seasonal_test_args)
 
-        if D > 0 and exogenous is not None:
-            diffxreg = diff(exogenous, differences=D, lag=m)
+        if D > 0 and X is not None:
+            diffxreg = diff(X, differences=D, lag=m)
             # check for constance on any column
             if np.apply_along_axis(is_constant, arr=diffxreg, axis=0).any():
                 D -= 1
@@ -485,11 +547,11 @@ def auto_arima(y,
                          % D)
 
     # difference the exogenous matrix
-    if exogenous is not None:
+    if X is not None:
         if D > 0:
-            diffxreg = diff(exogenous, differences=D, lag=m)
+            diffxreg = diff(X, differences=D, lag=m)
         else:
-            diffxreg = exogenous
+            diffxreg = X
     else:
         # here's the thing... we're only going to use diffxreg if exogenous
         # was not None in the first place. However, PyCharm doesn't know that
@@ -506,7 +568,7 @@ def auto_arima(y,
                    max_d=max_d,
                    **offset_test_args)
 
-        if d > 0 and exogenous is not None:
+        if d > 0 and X is not None:
             diffxreg = diff(diffxreg, differences=d, lag=1)
 
             # if any columns are constant, subtract one order of differencing
@@ -557,7 +619,7 @@ def auto_arima(y,
             solvers._sort_and_filter_fits(
                 fit_partial(
                     y,
-                    xreg=exogenous,
+                    xreg=X,
                     order=(0, d, 0),
                     seasonal_order=ssn,
                     with_intercept=with_intercept,
@@ -633,7 +695,7 @@ def auto_arima(y,
         all_res = Parallel(n_jobs=n_jobs)(
             delayed(fit_partial)(
                 y,
-                xreg=exogenous,
+                xreg=X,
                 order=order,
                 seasonal_order=seasonal_order,
                 with_intercept=with_intercept,
@@ -658,7 +720,7 @@ def auto_arima(y,
 
         # init the stepwise model wrapper
         stepwise_wrapper = solvers._StepwiseFitWrapper(
-            y, xreg=exogenous, start_params=start_params, trend=trend,
+            y, xreg=X, start_params=start_params, trend=trend,
             method=method, maxiter=maxiter, fit_params=fit_args,
             suppress_warnings=suppress_warnings, trace=trace,
             error_action=error_action, out_of_sample_size=out_of_sample_size,
@@ -678,7 +740,7 @@ def auto_arima(y,
 # Assign the doc to the auto_arima func
 auto_arima.__doc__ = _doc._AUTO_ARIMA_DOCSTR.format(
     y=_doc._Y_DOCSTR,
-    exogenous=_doc._EXOG_DOCSTR,
+    X=_doc._EXOG_DOCSTR,
     fit_args=_doc._FIT_ARGS_DOCSTR,
     sarimax_kwargs=_doc._SARIMAX_ARGS_DOCSTR,
     return_valid_fits=_doc._VALID_FITS_DOCSTR

--- a/pmdarima/arima/tests/test_auto.py
+++ b/pmdarima/arima/tests/test_auto.py
@@ -115,7 +115,7 @@ def test_force_polynomial_error():
 
     with pytest.raises(ValueError) as ve, \
             pytest.warns(ModelFitWarning) as mfw:
-        pm.auto_arima(x, d=d, D=0, seasonal=False, exogenous=xreg, trace=2)
+        pm.auto_arima(x, d=d, D=0, seasonal=False, X=xreg, trace=2)
 
     err_msg = pytest_error_str(ve)
     assert 'simple polynomial' in err_msg, err_msg
@@ -251,14 +251,14 @@ def test_random_with_oob(endog):
                   maxiter=3)
 
 
-# Test if exogenous is not None and D > 0
+# Test if X is not None and D > 0
 @pytest.mark.parametrize('m', [2])  # , 12])
 def test_seasonal_xreg_differencing(m):
     # Test both a small M and a large M since M is used as the lag parameter
     # in the xreg array differencing. If M is 1, D is set to 0
     _ = pm.auto_arima(wineind, d=1, D=1,  # noqa: F841
                       seasonal=True,
-                      exogenous=wineind_xreg, error_action='ignore',
+                      X=wineind_xreg, error_action='ignore',
                       suppress_warnings=True, m=m,
 
                       # Set to super low iter to make test move quickly
@@ -396,7 +396,7 @@ def test_with_seasonality3():
 
 
 def test_with_seasonality4():
-    # can we fit the same thing with an exogenous array of predictors?
+    # can we fit the same thing with an X array of predictors?
     # also make it stationary and make sure that works...
     # 9/22/18 - make not parallel to reduce mem overhead on pytest
     all_res = pm.auto_arima(wineind, start_p=1, start_q=1, max_p=2,
@@ -405,7 +405,7 @@ def test_with_seasonality4():
                             suppress_warnings=True, stationary=True,
                             random_state=42, return_valid_fits=True,
                             stepwise=True,
-                            exogenous=rs.rand(wineind.shape[0], 4),
+                            X=rs.rand(wineind.shape[0], 4),
 
                             # Set to super low iter to make test move quickly
                             maxiter=5)

--- a/pmdarima/base.py
+++ b/pmdarima/base.py
@@ -14,10 +14,10 @@ class BaseARIMA(BaseEstimator, metaclass=ABCMeta):
     """A base ARIMA class"""
 
     @abc.abstractmethod
-    def fit(self, y, exogenous, **fit_args):
+    def fit(self, y, X, **fit_args):
         """Fit an ARIMA model"""
 
-    def fit_predict(self, y, exogenous=None, n_periods=10, **fit_args):
+    def fit_predict(self, y, X=None, n_periods=10, **fit_args):
         """Fit an ARIMA to a vector, ``y``, of observations with an
         optional matrix of ``exogenous`` variables, and then generate
         predictions.
@@ -31,7 +31,7 @@ class BaseARIMA(BaseEstimator, metaclass=ABCMeta):
             one-dimensional array of floats, and should not contain any
             ``np.nan`` or ``np.inf`` values.
 
-        exogenous : array-like, shape=[n_obs, n_vars], optional (default=None)
+        X : array-like, shape=[n_obs, n_vars], optional (default=None)
             An optional 2-d array of exogenous variables. If provided, these
             variables are used as additional features in the regression
             operation. This should not include a constant or trend. Note that
@@ -44,17 +44,22 @@ class BaseARIMA(BaseEstimator, metaclass=ABCMeta):
         fit_args : dict or kwargs, optional (default=None)
             Any keyword args to pass to the fit method.
         """
-        self.fit(y, exogenous, **fit_args)
-        return self.predict(n_periods=n_periods, exogenous=exogenous)
+        self.fit(y, X, **fit_args)
+
+        # TODO: remove kwargs from call
+        return self.predict(n_periods=n_periods, X=X, **fit_args)
+
+    # TODO: remove kwargs from all of these
 
     @abc.abstractmethod
-    def predict(self, n_periods, exogenous, return_conf_int=False, alpha=0.05):
+    def predict(self, n_periods, X, return_conf_int=False, alpha=0.05,
+                **kwargs):
         """Create forecasts on a fitted model"""
 
     @abc.abstractmethod
-    def predict_in_sample(self, exogenous, start, end, dynamic):
+    def predict_in_sample(self, X, start, end, dynamic, **kwargs):
         """Get in-sample forecasts"""
 
     @abc.abstractmethod
-    def update(self, y, exogenous=None, maxiter=None, **kwargs):
+    def update(self, y, X=None, maxiter=None, **kwargs):
         """Update an ARIMA model"""

--- a/pmdarima/compat/__init__.py
+++ b/pmdarima/compat/__init__.py
@@ -6,6 +6,7 @@ to other portions of pmdarima and to remove circular dependencies.
 
 from .matplotlib import *
 from .pandas import *
+from .pmdarima import *
 from .numpy import *
 from .sklearn import *
 from .statsmodels import *

--- a/pmdarima/compat/pmdarima.py
+++ b/pmdarima/compat/pmdarima.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import warnings
+
+
+def get_X(X, **kwargs):
+    """Get the exogenous array
+
+    Gets the X array or ``exogenous`` array from ``kwargs``, warning for
+    deprecation of old key-word arguments, and amends the ``kwargs`` array.
+    """
+    exog = kwargs.pop("exogenous", None)
+    if X is not None and exog is not None:
+        raise ValueError("Multiple values provided for both X and exogenous")
+
+    if exog is not None:
+        warnings.warn(
+            "The `exogenous` key-word has been deprecated. Please "
+            "use `X` instead. This will raise an error in future "
+            "versions. For more information, see: "
+            "http://alkaline-ml.com/pmdarima/develop/rfc/372-exog-to-x.html",
+            DeprecationWarning
+        )
+        X = exog
+
+    return X, kwargs

--- a/pmdarima/compat/pytest.py
+++ b/pmdarima/compat/pytest.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import contextlib
+import pytest
+
 
 def pytest_error_str(error):
     """Different for different versions of Pytest"""
@@ -12,3 +15,14 @@ def pytest_error_str(error):
 def pytest_warning_messages(warnings):
     """Get the warning messages for captured warnings"""
     return [str(w.message) for w in warnings.list]
+
+
+@contextlib.contextmanager
+def raises(exception):
+    """Allows context managers for catching NO errors"""
+    if exception is None:
+        yield None
+
+    else:
+        with pytest.raises(exception) as e:
+            yield e

--- a/pmdarima/compat/tests/test_pmdarima.py
+++ b/pmdarima/compat/tests/test_pmdarima.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from pmdarima.compat import pmdarima as pm_compat
+from pmdarima.compat import pytest as pt_compat
+
+xreg = np.random.rand(4, 4)
+
+
+@pytest.mark.parametrize(
+    'X,kw,X_exp,kw_exp,exp_warning,exp_error', [
+
+        # provided as `exogenous`
+        pytest.param(
+            None,
+            {"exogenous": xreg},
+            xreg,
+            {},
+            DeprecationWarning,
+            None,
+        ),
+
+        # provided as `X` with additional kwargs
+        pytest.param(
+            xreg,
+            {"foo": "bar"},
+            xreg,
+            {"foo": "bar"},
+            None,
+            None,
+        ),
+
+        # provided as `X` AND `exogenous` will raise
+        pytest.param(
+            xreg,
+            {"exogenous": xreg},
+            None,
+            None,
+            None,
+            ValueError,
+        ),
+
+    ]
+)
+def test_get_X(X, kw, X_exp, kw_exp, exp_warning, exp_error):
+    with pytest.warns(exp_warning) as w, \
+            pt_compat.raises(exp_error) as e:
+        X_act, kw_act = pm_compat.get_X(X, **kw)
+
+    if exp_warning:
+        assert w
+    else:
+        assert not w
+
+    if exp_error:
+        assert e
+        # no other assertions can be made
+    else:
+        assert not e
+        assert_array_equal(X_act, X_exp)
+        assert kw_act == kw_exp

--- a/pmdarima/model_selection/_split.py
+++ b/pmdarima/model_selection/_split.py
@@ -113,9 +113,9 @@ class BaseTSCrossValidator(BaseEstimator, metaclass=abc.ABCMeta):
         # Temporary shim until we remove `exogenous` support completely
         X, _ = pm_compat.get_X(X, **kwargs)
 
-        y, exog = indexable(y, X)
+        y, X = indexable(y, X)
         indices = np.arange(y.shape[0])
-        for train_index, test_index in self._iter_train_test_masks(y, exog):
+        for train_index, test_index in self._iter_train_test_masks(y, X):
             train_index = indices[train_index]
             test_index = indices[test_index]
             yield train_index, test_index

--- a/pmdarima/model_selection/_split.py
+++ b/pmdarima/model_selection/_split.py
@@ -7,6 +7,8 @@ from sklearn.base import BaseEstimator
 from sklearn.utils.validation import indexable
 from sklearn.model_selection import train_test_split as tts
 
+from ..compat import pmdarima as pm_compat
+
 __all__ = [
     'check_cv',
     'train_test_split',
@@ -89,7 +91,7 @@ class BaseTSCrossValidator(BaseEstimator, metaclass=abc.ABCMeta):
         """The forecast horizon for the cross-validator"""
         return self.h
 
-    def split(self, y, exogenous=None):
+    def split(self, y, X=None, **kwargs):  # TODO: remove kwargs
         """Generate indices to split data into training and test sets
 
         Parameters
@@ -97,7 +99,7 @@ class BaseTSCrossValidator(BaseEstimator, metaclass=abc.ABCMeta):
         y : array-like or iterable, shape=(n_samples,)
             The time-series array.
 
-        exogenous : array-like, shape=[n_obs, n_vars], optional (default=None)
+        X : array-like, shape=[n_obs, n_vars], optional (default=None)
             An optional 2-d array of exogenous variables.
 
         Yields
@@ -108,16 +110,19 @@ class BaseTSCrossValidator(BaseEstimator, metaclass=abc.ABCMeta):
         test : np.ndarray
             The test set indices for the split
         """
-        y, exog = indexable(y, exogenous)
+        # Temporary shim until we remove `exogenous` support completely
+        X, _ = pm_compat.get_X(X, **kwargs)
+
+        y, exog = indexable(y, X)
         indices = np.arange(y.shape[0])
         for train_index, test_index in self._iter_train_test_masks(y, exog):
             train_index = indices[train_index]
             test_index = indices[test_index]
             yield train_index, test_index
 
-    def _iter_train_test_masks(self, y, exog):
+    def _iter_train_test_masks(self, y, X):
         """Generate boolean masks corresponding to test sets"""
-        for train_index, test_index in self._iter_train_test_indices(y, exog):
+        for train_index, test_index in self._iter_train_test_indices(y, X):
             train_mask = np.zeros(y.shape[0], dtype=np.bool)
             test_mask = np.zeros(y.shape[0], dtype=np.bool)
 
@@ -126,7 +131,7 @@ class BaseTSCrossValidator(BaseEstimator, metaclass=abc.ABCMeta):
             yield train_mask, test_mask
 
     @abc.abstractmethod
-    def _iter_train_test_indices(self, y, exog):
+    def _iter_train_test_indices(self, y, X):
         """Yields the train/test indices"""
 
 
@@ -215,7 +220,7 @@ class RollingForecastCV(BaseTSCrossValidator):
         super().__init__(h, step)
         self.initial = initial
 
-    def _iter_train_test_indices(self, y, exog):
+    def _iter_train_test_indices(self, y, X):
         """Yields the train/test indices"""
         n_samples = y.shape[0]
         initial = self.initial
@@ -312,7 +317,7 @@ class SlidingWindowForecastCV(BaseTSCrossValidator):
         super().__init__(h, step)
         self.window_size = window_size
 
-    def _iter_train_test_indices(self, y, exog):
+    def _iter_train_test_indices(self, y, X):
         """Yields the train/test indices"""
         n_samples = y.shape[0]
         window_size = self.window_size

--- a/pmdarima/model_selection/_validation.py
+++ b/pmdarima/model_selection/_validation.py
@@ -19,6 +19,7 @@ from .. import metrics
 from ..utils import check_endog
 from ..arima.warnings import ModelFitWarning
 from ..compat.sklearn import safe_indexing
+from ..compat import pmdarima as pm_compat
 
 __all__ = [
     'cross_validate',
@@ -72,7 +73,7 @@ def _safe_split(y, exog, train, test):
     return y_train, y_test, exog_train, exog_test
 
 
-def _fit_and_score(fold, estimator, y, exog, scorer, train, test, verbose,
+def _fit_and_score(fold, estimator, y, X, scorer, train, test, verbose,
                    error_score):
     """Fit estimator and compute scores for a given dataset split."""
     msg = 'fold=%i' % fold
@@ -80,10 +81,10 @@ def _fit_and_score(fold, estimator, y, exog, scorer, train, test, verbose,
         print("[CV] %s %s" % (msg, (64 - len(msg)) * '.'))
 
     start_time = time.time()
-    y_train, y_test, exog_train, exog_test = _safe_split(y, exog, train, test)
+    y_train, y_test, exog_train, exog_test = _safe_split(y, X, train, test)
 
     try:
-        estimator.fit(y_train, exogenous=exog_train)
+        estimator.fit(y_train, X=exog_train)
 
     except Exception as e:
         fit_time = time.time() - start_time
@@ -102,7 +103,7 @@ def _fit_and_score(fold, estimator, y, exog, scorer, train, test, verbose,
         fit_time = time.time() - start_time
 
         # forecast h periods into the future and compute the score
-        preds = estimator.predict(n_periods=len(test), exogenous=exog_test)
+        preds = estimator.predict(n_periods=len(test), X=exog_test)
         test_scores = scorer(y_test, preds)
         score_time = time.time() - start_time - fit_time
 
@@ -115,22 +116,22 @@ def _fit_and_score(fold, estimator, y, exog, scorer, train, test, verbose,
     return test_scores, fit_time, score_time
 
 
-def _fit_and_predict(fold, estimator, y, exog, train, test, verbose):
+def _fit_and_predict(fold, estimator, y, X, train, test, verbose):
     """Fit estimator and compute scores for a given dataset split."""
     msg = 'fold=%i' % fold
     if verbose > 1:
         print("[CV] %s %s" % (msg, (64 - len(msg)) * '.'))
 
     start_time = time.time()
-    y_train, _, exog_train, exog_test = _safe_split(y, exog, train, test)
+    y_train, _, exog_train, exog_test = _safe_split(y, X, train, test)
 
     # scikit doesn't handle failures on cv predict, so we won't either.
-    estimator.fit(y_train, exogenous=exog_train)
+    estimator.fit(y_train, X=exog_train)
     fit_time = time.time() - start_time
 
     # forecast h periods into the future
     start_time = time.time()
-    preds = estimator.predict(n_periods=len(test), exogenous=exog_test)
+    preds = estimator.predict(n_periods=len(test), X=exog_test)
     pred_time = time.time() - start_time
 
     if verbose > 2:
@@ -141,8 +142,14 @@ def _fit_and_predict(fold, estimator, y, exog, train, test, verbose):
     return preds, test
 
 
-def cross_validate(estimator, y, exogenous=None, scoring=None, cv=None,
-                   verbose=0, error_score=np.nan):
+def cross_validate(estimator,
+                   y,
+                   X=None,
+                   scoring=None,
+                   cv=None,
+                   verbose=0,
+                   error_score=np.nan,
+                   **kwargs):  # TODO: remove kwargs
     """Evaluate metric(s) by cross-validation and also record fit/score times.
 
     Parameters
@@ -153,7 +160,7 @@ def cross_validate(estimator, y, exogenous=None, scoring=None, cv=None,
     y : array-like or iterable, shape=(n_samples,)
             The time-series array.
 
-    exogenous : array-like, shape=[n_obs, n_vars], optional (default=None)
+    X : array-like, shape=[n_obs, n_vars], optional (default=None)
         An optional 2-d array of exogenous variables.
 
     scoring : str or callable, optional (default=None)
@@ -176,7 +183,10 @@ def cross_validate(estimator, y, exogenous=None, scoring=None, cv=None,
         If a numeric value is given, ModelFitWarning is raised. This parameter
         does not affect the refit step, which will always raise the error.
     """
-    y, exog = indexable(y, exogenous)
+    # Temporary shim until we remove `exogenous` support completely
+    X, _ = pm_compat.get_X(X, **kwargs)
+
+    y, X = indexable(y, X)
     y = check_endog(y, copy=False)
 
     cv = check_cv(cv)
@@ -191,13 +201,16 @@ def cross_validate(estimator, y, exogenous=None, scoring=None, cv=None,
     #   . could cause cross threads in parallelism..
 
     results = [
-        _fit_and_score(fold, base.clone(estimator), y, exog,
+        _fit_and_score(fold,
+                       base.clone(estimator),
+                       y,
+                       X,
                        scorer=scoring,
                        train=train,
                        test=test,
                        verbose=verbose,
                        error_score=error_score)
-        for fold, (train, test) in enumerate(cv.split(y, exog))]
+        for fold, (train, test) in enumerate(cv.split(y, X))]
     scores, fit_times, score_times = list(zip(*results))
 
     ret = {
@@ -208,8 +221,13 @@ def cross_validate(estimator, y, exogenous=None, scoring=None, cv=None,
     return ret
 
 
-def cross_val_predict(estimator, y, exogenous=None, cv=None, verbose=0,
-                      averaging="mean"):
+def cross_val_predict(estimator,
+                      y,
+                      X=None,
+                      cv=None,
+                      verbose=0,
+                      averaging="mean",
+                      **kwargs):  # TODO: remove kwargs
     """Generate cross-validated estimates for each input data point
 
     Parameters
@@ -220,7 +238,7 @@ def cross_val_predict(estimator, y, exogenous=None, cv=None, verbose=0,
     y : array-like or iterable, shape=(n_samples,)
             The time-series array.
 
-    exogenous : array-like, shape=[n_obs, n_vars], optional (default=None)
+    X : array-like, shape=[n_obs, n_vars], optional (default=None)
         An optional 2-d array of exogenous variables.
 
     cv : BaseTSCrossValidator or None, optional (default=None)
@@ -263,7 +281,10 @@ def cross_val_predict(estimator, y, exogenous=None, cv=None, verbose=0,
     array([30710.45743168, 34902.94929722, 17994.16587163, 22127.71167249,
            25473.60876435])
     """
-    y, exog = indexable(y, exogenous)
+    # Temporary shim until we remove `exogenous` support completely
+    X, _ = pm_compat.get_X(X, **kwargs)
+
+    y, X = indexable(y, X)
     y = check_endog(y, copy=False)
     cv = check_cv(cv)
     avgfunc = _check_averaging(averaging)
@@ -290,11 +311,14 @@ def cross_val_predict(estimator, y, exogenous=None, cv=None, verbose=0,
 
     # clone estimator to make sure all folds are independent
     prediction_blocks = [
-        _fit_and_predict(fold, base.clone(estimator), y, exog,
+        _fit_and_predict(fold,
+                         base.clone(estimator),
+                         y,
+                         X,
                          train=train,
                          test=test,
                          verbose=verbose,)  # TODO: fit params?
-        for fold, (train, test) in enumerate(cv.split(y, exog))]
+        for fold, (train, test) in enumerate(cv.split(y, X))]
 
     # Unlike normal CV, time series CV might have different folds (windows)
     # forecasting the same time step. In this stage, we build a matrix of
@@ -311,8 +335,14 @@ def cross_val_predict(estimator, y, exogenous=None, cv=None, verbose=0,
     return avgfunc(predictions, axis=1)
 
 
-def cross_val_score(estimator, y, exogenous=None, scoring=None, cv=None,
-                    verbose=0, error_score=np.nan):
+def cross_val_score(estimator,
+                    y,
+                    X=None,
+                    scoring=None,
+                    cv=None,
+                    verbose=0,
+                    error_score=np.nan,
+                    **kwargs):  # TODO: remove kwargs
     """Evaluate a score by cross-validation
 
     Parameters
@@ -323,7 +353,7 @@ def cross_val_score(estimator, y, exogenous=None, scoring=None, cv=None,
     y : array-like or iterable, shape=(n_samples,)
             The time-series array.
 
-    exogenous : array-like, shape=[n_obs, n_vars], optional (default=None)
+    X : array-like, shape=[n_obs, n_vars], optional (default=None)
         An optional 2-d array of exogenous variables.
 
     scoring : str or callable, optional (default=None)
@@ -346,8 +376,14 @@ def cross_val_score(estimator, y, exogenous=None, scoring=None, cv=None,
         If a numeric value is given, ModelFitWarning is raised. This parameter
         does not affect the refit step, which will always raise the error.
     """
-    cv_results = cross_validate(estimator=estimator, y=y, exogenous=exogenous,
-                                scoring=scoring, cv=cv,
+    # Temporary shim until we remove `exogenous` support completely
+    X, _ = pm_compat.get_X(X, **kwargs)
+
+    cv_results = cross_validate(estimator=estimator,
+                                y=y,
+                                X=X,
+                                scoring=scoring,
+                                cv=cv,
                                 verbose=verbose,
                                 error_score=error_score)
     return cv_results['test_score']

--- a/pmdarima/model_selection/tests/test_validation.py
+++ b/pmdarima/model_selection/tests/test_validation.py
@@ -39,10 +39,10 @@ exogenous = np.random.RandomState(1).rand(y.shape[0], 2)
     ]
 )
 @pytest.mark.parametrize('verbose', [0, 2, 4])
-@pytest.mark.parametrize('exog', [None, exogenous])
-def test_cv_scores(cv, est, verbose, exog):
+@pytest.mark.parametrize('X', [None, exogenous])
+def test_cv_scores(cv, est, verbose, X):
     scores = cross_val_score(
-        est, y, exogenous=exog, scoring='mean_squared_error',
+        est, y, X=X, scoring='mean_squared_error',
         cv=cv, verbose=verbose)
     assert isinstance(scores, np.ndarray)
 

--- a/pmdarima/preprocessing/base.py
+++ b/pmdarima/preprocessing/base.py
@@ -29,18 +29,17 @@ class BaseTransformer(BaseEstimator, TransformerMixin, metaclass=abc.ABCMeta):
     of the same schema.
     """
     @staticmethod
-    def _check_y_exog(y, exog):
+    def _check_y_X(y, X):
         """Validate input"""
         # Do not force finite, since a transformer's goal may be imputation.
         if y is not None:
             y = check_endog(y, dtype=DTYPE, copy=True, force_all_finite=False)
 
-        if exog is not None:
-            exog = check_exog(
-                exog, dtype=None, copy=True, force_all_finite=False)
-        return y, exog
+        if X is not None:
+            X = check_exog(X, dtype=None, copy=True, force_all_finite=False)
+        return y, X
 
-    def fit_transform(self, y, exogenous=None, **transform_kwargs):
+    def fit_transform(self, y, X=None, **kwargs):
         """Fit and transform the arrays
 
         Parameters
@@ -48,17 +47,17 @@ class BaseTransformer(BaseEstimator, TransformerMixin, metaclass=abc.ABCMeta):
         y : array-like or None, shape=(n_samples,)
             The endogenous (time-series) array.
 
-        exogenous : array-like or None, shape=(n_samples, n_features), optional
+        X : array-like or None, shape=(n_samples, n_features), optional
             The exogenous array of additional covariates.
 
-        **transform_kwargs : keyword args
+        **kwargs : keyword args
             Keyword arguments required by the transform function.
         """
-        self.fit(y, exogenous)
-        return self.transform(y, exogenous, **transform_kwargs)
+        self.fit(y, X, **kwargs)  # TODO: eventually do not pass kwargs to fit
+        return self.transform(y, X, **kwargs)
 
     @abc.abstractmethod
-    def fit(self, y, exogenous):
+    def fit(self, y, X, **kwargs):  # TODO: eventually remove kwargs from fit
         """Fit the transformer
 
         The purpose of the ``fit`` method is to learn a set of statistics or
@@ -72,7 +71,7 @@ class BaseTransformer(BaseEstimator, TransformerMixin, metaclass=abc.ABCMeta):
         y : array-like or None, shape=(n_samples,)
             The endogenous (time-series) array.
 
-        exogenous : array-like or None, shape=(n_samples, n_features)
+        X : array-like or None, shape=(n_samples, n_features)
             The exogenous array of additional covariates.
 
         Returns
@@ -84,7 +83,7 @@ class BaseTransformer(BaseEstimator, TransformerMixin, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def transform(self, y, exogenous, **kwargs):
+    def transform(self, y, X, **kwargs):
         """Transform the new array
 
         Apply the transformation to the array after learning the training set's
@@ -95,7 +94,7 @@ class BaseTransformer(BaseEstimator, TransformerMixin, metaclass=abc.ABCMeta):
         y : array-like or None, shape=(n_samples,)
             The endogenous (time-series) array.
 
-        exogenous : array-like or None, shape=(n_samples, n_features)
+        X : array-like or None, shape=(n_samples, n_features)
             The exogenous array of additional covariates.
 
         **kwargs : keyword args
@@ -106,8 +105,8 @@ class BaseTransformer(BaseEstimator, TransformerMixin, metaclass=abc.ABCMeta):
         y : array-like or None
             The transformed y array
 
-        exogenous : array-like or None
-            The transformed exogenous array
+        X : array-like or None
+            The transformed X array
         """
 
 
@@ -118,7 +117,9 @@ class UpdatableMixin:
         if y is None:
             raise ValueError("endog array cannot be None when updating")
 
-    def update_and_transform(self, y, exogenous, **kwargs):
+    # TODO: remove default None value for X when we remove kwargs
+
+    def update_and_transform(self, y, X=None, **kwargs):
         """Update the params and return the transformed arrays
 
         Parameters
@@ -126,7 +127,7 @@ class UpdatableMixin:
         y : array-like or None, shape=(n_samples,)
             The endogenous (time-series) array.
 
-        exogenous : array-like or None, shape=(n_samples, n_features)
+        X : array-like or None, shape=(n_samples, n_features)
             The exogenous array of additional covariates.
 
         **kwargs : keyword args

--- a/pmdarima/preprocessing/endog/base.py
+++ b/pmdarima/preprocessing/endog/base.py
@@ -8,15 +8,15 @@ from ..base import BaseTransformer
 class BaseEndogTransformer(BaseTransformer, metaclass=abc.ABCMeta):
     """A base class for endogenous array transformers"""
 
-    def _check_y_exog(self, y, exog):
+    def _check_y_X(self, y, X):
         """Check the endog and exog arrays"""
-        y, exog = super(BaseEndogTransformer, self)._check_y_exog(y, exog)
+        y, X = super(BaseEndogTransformer, self)._check_y_X(y, X)
         if y is None:
             raise ValueError("y must be non-None for endogenous transformers")
-        return y, exog
+        return y, X
 
     @abc.abstractmethod
-    def inverse_transform(self, y, exogenous=None):
+    def inverse_transform(self, y, X=None, **kwargs):  # TODO: remove kwargs
         """Inverse transform a transformed array
 
         Inverse the transformation on the transformed array.
@@ -26,7 +26,7 @@ class BaseEndogTransformer(BaseTransformer, metaclass=abc.ABCMeta):
         y : array-like or None, shape=(n_samples,)
             The transformed endogenous (time-series) array.
 
-        exogenous : array-like or None, shape=(n_samples, n_features), optional
+        X : array-like or None, shape=(n_samples, n_features), optional
             The exogenous array of additional covariates. Not used for
             endogenous transformers. Default is None, and non-None values will
             serve as pass-through arrays.
@@ -36,6 +36,6 @@ class BaseEndogTransformer(BaseTransformer, metaclass=abc.ABCMeta):
         y : array-like or None
             The inverse-transformed y array
 
-        exogenous : array-like or None
+        X : array-like or None
             The inverse-transformed exogenous array
         """

--- a/pmdarima/preprocessing/endog/log.py
+++ b/pmdarima/preprocessing/endog/log.py
@@ -34,7 +34,7 @@ class LogEndogTransformer(BoxCoxEndogTransformer):
 
         super().__init__(0, lmbda2=lmbda, neg_action=neg_action, floor=floor)
 
-    def fit(self, y, exogenous=None):
+    def fit(self, y, X=None, **kwargs):  # TODO: kwargs go away
         """Fit the transformer
 
         Must be called before ``transform``.
@@ -44,14 +44,14 @@ class LogEndogTransformer(BoxCoxEndogTransformer):
         y : array-like or None, shape=(n_samples,)
             The endogenous (time-series) array.
 
-        exogenous : array-like or None, shape=(n_samples, n_features), optional
+        X : array-like or None, shape=(n_samples, n_features), optional
             The exogenous array of additional covariates. Not used for
             endogenous transformers. Default is None, and non-None values will
             serve as pass-through arrays.
         """
-        return super().fit(y, exogenous)
+        return super().fit(y, X, **kwargs)
 
-    def transform(self, y, exogenous=None, **transform_kwargs):
+    def transform(self, y, X=None, **transform_kwargs):
         """Apply the log transform to the array
 
         Parameters
@@ -59,7 +59,7 @@ class LogEndogTransformer(BoxCoxEndogTransformer):
         y : array-like or None, shape=(n_samples,)
             The endogenous (time-series) array.
 
-        exogenous : array-like or None, shape=(n_samples, n_features), optional
+        X : array-like or None, shape=(n_samples, n_features), optional
             The exogenous array of additional covariates. Not used for
             endogenous transformers. Default is None, and non-None values will
             serve as pass-through arrays.
@@ -69,12 +69,12 @@ class LogEndogTransformer(BoxCoxEndogTransformer):
         y_transform : array-like or None
             The log transformed y array
 
-        exogenous : array-like or None
+        X : array-like or None
             The exog array
         """
-        return super().transform(y, exogenous, **transform_kwargs)
+        return super().transform(y, X, **transform_kwargs)
 
-    def inverse_transform(self, y, exogenous=None):
+    def inverse_transform(self, y, X=None, **kwargs):  # TODO: kwargs go away
         """Inverse transform a transformed array
 
         Inverse the log transformation on the transformed array. Note that
@@ -85,19 +85,19 @@ class LogEndogTransformer(BoxCoxEndogTransformer):
         Parameters
         ----------
         y : array-like or None, shape=(n_samples,)
-        The transformed endogenous (time-series) array.
+            The transformed endogenous (time-series) array.
 
-        exogenous : array-like or None, shape=(n_samples, n_features), optional
-        The exogenous array of additional covariates. Not used for
-        endogenous transformers. Default is None, and non-None values will
-        serve as pass-through arrays.
+        X : array-like or None, shape=(n_samples, n_features), optional
+            The exogenous array of additional covariates. Not used for
+            endogenous transformers. Default is None, and non-None values will
+            serve as pass-through arrays.
 
         Returns
         -------
         y : array-like or None
-        The inverse-transformed y array
+            The inverse-transformed y array
 
-        exogenous : array-like or None
-        The inverse-transformed exogenous array
+        X : array-like or None
+            The inverse-transformed exogenous array
         """
-        return super().inverse_transform(y, exogenous=exogenous)
+        return super().inverse_transform(y, X, **kwargs)

--- a/pmdarima/preprocessing/endog/tests/test_base.py
+++ b/pmdarima/preprocessing/endog/tests/test_base.py
@@ -8,5 +8,5 @@ from pmdarima.preprocessing.endog import LogEndogTransformer
 def test_value_error_on_check():
     trans = LogEndogTransformer()  # could be anything, just need an instance
     with pytest.raises(ValueError) as ve:
-        trans._check_y_exog(None, None)
+        trans._check_y_X(None, None)
     assert 'non-None' in pytest_error_str(ve)

--- a/pmdarima/preprocessing/endog/tests/test_boxcox.py
+++ b/pmdarima/preprocessing/endog/tests/test_boxcox.py
@@ -12,24 +12,24 @@ loggamma = stats.loggamma.rvs(5, size=500) + 5
 
 
 @pytest.mark.parametrize(
-    'exog', [
+    'X', [
         None,
         np.random.rand(loggamma.shape[0], 3),
     ]
 )
-def test_invertible(exog):
+def test_invertible(X):
     trans = BoxCoxEndogTransformer()
-    y_t, e_t = trans.fit_transform(loggamma, exogenous=exog)
-    y_prime, e_prime = trans.inverse_transform(y_t, exogenous=e_t)
+    y_t, e_t = trans.fit_transform(loggamma, X=X)
+    y_prime, e_prime = trans.inverse_transform(y_t, X=e_t)
 
     assert_array_almost_equal(loggamma, y_prime)
 
-    # exog should all be the same too
-    if exog is None:
-        assert exog is e_t is e_prime is None
+    # X should all be the same too
+    if X is None:
+        assert X is e_t is e_prime is None
     else:
-        assert_array_almost_equal(exog, e_t)
-        assert_array_almost_equal(exog, e_prime)
+        assert_array_almost_equal(X, e_t)
+        assert_array_almost_equal(X, e_prime)
 
 
 def test_invertible_when_lambda_is_0():

--- a/pmdarima/preprocessing/exog/tests/test_base.py
+++ b/pmdarima/preprocessing/exog/tests/test_base.py
@@ -14,28 +14,28 @@ class RandomExogFeaturizer(base.BaseExogFeaturizer):
     def _get_prefix(self):
         return "RND"
 
-    def fit(self, y, exogenous):
+    def fit(self, y, X, **_):
         return self
 
-    def transform(self, y, exogenous=None, n_periods=0, **_):
-        exog = np.random.rand(y.shape[0], 4)
-        exog = self._safe_hstack(exogenous, exog)
-        return y, exog
+    def transform(self, y, X=None, n_periods=0, **_):
+        Xt = np.random.rand(y.shape[0], 4)
+        Xt = self._safe_hstack(X, Xt)
+        return y, Xt
 
 
 def test_default_get_feature_names():
     feat = RandomExogFeaturizer()
-    y_trans, exog = feat.fit_transform(wineind)
+    y_trans, X = feat.fit_transform(wineind)
     assert y_trans is wineind
-    assert exog.columns.tolist() == \
+    assert X.columns.tolist() == \
         ['RND_0', 'RND_1', 'RND_2', 'RND_3']
 
 
-def test_default_get_feature_names_with_exog():
+def test_default_get_feature_names_with_X():
     feat = RandomExogFeaturizer()
-    exog = pd.DataFrame.from_records(np.random.rand(wineind.shape[0], 2),
-                                     columns=['a', 'b'])
-    y_trans, exog_trans = feat.fit_transform(wineind, exog)
+    X = pd.DataFrame.from_records(
+        np.random.rand(wineind.shape[0], 2), columns=['a', 'b'])
+    y_trans, X_trans = feat.fit_transform(wineind, X)
     assert y_trans is wineind
-    assert exog_trans.columns.tolist() == \
+    assert X_trans.columns.tolist() == \
         ['a', 'b', 'RND_0', 'RND_1', 'RND_2', 'RND_3']

--- a/pmdarima/preprocessing/exog/tests/test_dates.py
+++ b/pmdarima/preprocessing/exog/tests/test_dates.py
@@ -47,7 +47,7 @@ def test_numpy_array_fails():
     with pytest.raises(TypeError) as te:
         feat.fit_transform(y, X.values)
 
-    assert "exog must be" in pytest_error_str(te)
+    assert "X must be" in pytest_error_str(te)
 
 
 def _dummy_assertions(X_prime):

--- a/pmdarima/preprocessing/exog/tests/test_fourier.py
+++ b/pmdarima/preprocessing/exog/tests/test_fourier.py
@@ -56,30 +56,30 @@ class TestFourierREquivalency:
     ])
 
     @pytest.mark.parametrize(
-        'exog', [
+        'X', [
             None,
             np.random.rand(y.shape[0], 3)
         ]
     )
-    def test_r_equivalency(self, exog):
+    def test_r_equivalency(self, X):
         y = self.y
         expected = self.expected
 
         trans = FourierFeaturizer(m=5, k=2).fit(y)
-        _, xreg = trans.transform(y, exog)
+        _, xreg = trans.transform(y, X)
 
         # maybe subset
         if hasattr(xreg, 'iloc'):
             xreg = xreg.values
         assert_array_almost_equal(expected, xreg[:, -4:])
 
-        # maybe assert on exog
-        if exog is not None:
-            assert_array_almost_equal(exog, xreg[:, :3])
+        # maybe assert on X
+        if X is not None:
+            assert_array_almost_equal(X, xreg[:, :3])
 
-            # Test a bad forecast (exog dim does not match n_periods dim)
+            # Test a bad forecast (X dim does not match n_periods dim)
             with pytest.raises(ValueError):
-                trans.transform(y, exogenous=np.random.rand(5, 3), n_periods=2)
+                trans.transform(y, X=np.random.rand(5, 3), n_periods=2)
 
 
 def test_hyndman_blog():
@@ -94,7 +94,7 @@ def test_hyndman_blog():
     _, xreg = trans.transform(y)
 
     arima = pm.auto_arima(y,
-                          exogenous=xreg,
+                          X=xreg,
                           seasonal=False,
                           maxiter=2,  # very short
                           start_p=4,
@@ -106,7 +106,7 @@ def test_hyndman_blog():
 
     # Show we can forecast 10 in the future
     _, xreg_test = trans.transform(y, n_periods=10)
-    arima.predict(n_periods=10, exogenous=xreg_test)
+    arima.predict(n_periods=10, X=xreg_test)
 
 
 def test_update_transform():
@@ -121,7 +121,7 @@ def test_update_transform():
     _, xreg = trans.transform(train)
 
     # Now update with the test set and show the xreg is diff
-    yt, Xt = trans.update_and_transform(test, exogenous=None)
+    yt, Xt = trans.update_and_transform(test, X=None)
     assert yt is test
     assert Xt.shape[0] == test.shape[0]
     assert trans.n_ == y.shape[0]
@@ -137,7 +137,7 @@ def test_update_transform():
 def test_value_error_check():
     feat = FourierFeaturizer(m=12)
     with pytest.raises(ValueError) as ve:
-        feat._check_y_exog(wineind, None, null_allowed=False)
+        feat._check_y_X(wineind, None, null_allowed=False)
     assert 'non-None' in pytest_error_str(ve)
 
 

--- a/pmdarima/tests/test_pipeline.py
+++ b/pmdarima/tests/test_pipeline.py
@@ -182,14 +182,14 @@ def test_pipeline_behavior():
                             maxiter=3, error_action='ignore'))
     ]),
 ])
-@pytest.mark.parametrize('exog', [(None, None), (x_train, x_test)])
+@pytest.mark.parametrize('X', [(None, None), (x_train, x_test)])
 @pytest.mark.parametrize('inverse_transform', [True, False])
 @pytest.mark.parametrize('return_conf_ints', [True, False])
-def test_pipeline_predict_inverse_transform(pipeline, exog, inverse_transform,
+def test_pipeline_predict_inverse_transform(pipeline, X, inverse_transform,
                                             return_conf_ints):
-    exog_train, exog_test = exog
+    X_train, X_test = X
 
-    pipeline.fit(train, exogenous=exog_train)
+    pipeline.fit(train, X=X_train)
 
     # show we can get a summary
     pipeline.summary()
@@ -197,7 +197,7 @@ def test_pipeline_predict_inverse_transform(pipeline, exog, inverse_transform,
     # first predict
     predictions = pipeline.predict(
         n_periods=test.shape[0],
-        exogenous=exog_test,
+        X=X_test,
         inverse_transform=inverse_transform,
         return_conf_int=return_conf_ints)
 
@@ -211,7 +211,7 @@ def test_pipeline_predict_inverse_transform(pipeline, exog, inverse_transform,
 
     # now in sample
     in_sample = pipeline.predict_in_sample(
-        exogenous=exog_train,
+        X=X_train,
         inverse_transform=inverse_transform,
         return_conf_int=return_conf_ints)
 
@@ -243,8 +243,8 @@ def test_order_does_not_matter_with_date_transformer():
                             suppress_warnings=True,
                             maxiter=3, error_action='ignore'))
     ]).fit(train_y_dates, train_X_dates)
-    Xt_a = pipeline_a.transform(exogenous=test_X_dates)
-    pred_a = pipeline_a.predict(exogenous=test_X_dates)
+    Xt_a = pipeline_a.transform(X=test_X_dates)
+    pred_a = pipeline_a.predict(X=test_X_dates)
 
     pipeline_b = Pipeline([
         ('dates', DateFeaturizer(column_name="date", prefix="DATE")),
@@ -253,8 +253,8 @@ def test_order_does_not_matter_with_date_transformer():
                             suppress_warnings=True,
                             maxiter=3, error_action='ignore'))
     ]).fit(train_y_dates, train_X_dates)
-    Xt_b = pipeline_b.transform(exogenous=test_X_dates)
-    pred_b = pipeline_b.predict(exogenous=test_X_dates)
+    Xt_b = pipeline_b.transform(X=test_X_dates)
+    pred_b = pipeline_b.predict(X=test_X_dates)
 
     # dates in A should differ from those in B
     assert pipeline_a.x_feats_[0].startswith("FOURIER")


### PR DESCRIPTION
This replaces the `exogenous` keyword with `X`. For more information on this, see #372. Note that the `exogenous` keyword will still work with a `DeprecationWarning` until version 2.0 