### PR TITLE
[MRG+1] Fix upper bound in RollingForecastCV

### DIFF
--- a/pmdarima/model_selection/_split.py
+++ b/pmdarima/model_selection/_split.py
@@ -242,10 +242,15 @@ class RollingForecastCV(BaseTSCrossValidator):
         # Determine the number of iterations that will take place. Must
         # guarantee that the forecasting horizon will not over-index the series
         all_indices = np.arange(n_samples)
-        for train_step_size in range(0, n_samples - h - initial + 1, step):
-            train_size = initial + train_step_size
-            train_indices = all_indices[:train_size]
-            test_indices = all_indices[train_size: train_size + h]
+        window_start = 0
+        while True:
+            window_end = window_start + initial
+            if window_end + h > n_samples:
+                break
+
+            train_indices = all_indices[window_start: window_end]
+            test_indices = all_indices[window_end: window_end + h]
+            window_start += step
 
             yield train_indices, test_indices
 

--- a/pmdarima/model_selection/_split.py
+++ b/pmdarima/model_selection/_split.py
@@ -242,7 +242,7 @@ class RollingForecastCV(BaseTSCrossValidator):
         # Determine the number of iterations that will take place. Must
         # guarantee that the forecasting horizon will not over-index the series
         all_indices = np.arange(n_samples)
-        for train_step_size in range(0, n_samples - h - initial, step):
+        for train_step_size in range(0, n_samples - h - initial + 1, step):
             train_size = initial + train_step_size
             train_indices = all_indices[:train_size]
             test_indices = all_indices[train_size: train_size + h]

--- a/pmdarima/model_selection/tests/test_split.py
+++ b/pmdarima/model_selection/tests/test_split.py
@@ -127,3 +127,28 @@ def test_issue_364_bad_splits():
     # assert no extra splits
     with pytest.raises(StopIteration):
         next(gen)
+
+
+def test_rolling_forecast_cv_bad_splits():
+    endog = y[:100]
+    cv = RollingForecastCV(initial=90, step=1, h=4)
+    gen = cv.split(endog)
+
+    expected = [
+        (np.arange(0, 90), np.array([90, 91, 92, 93])),
+        (np.arange(1, 91), np.array([91, 92, 93, 94])),
+        (np.arange(2, 92), np.array([92, 93, 94, 95])),
+        (np.arange(3, 93), np.array([93, 94, 95, 96])),
+        (np.arange(4, 94), np.array([94, 95, 96, 97])),
+        (np.arange(5, 95), np.array([95, 96, 97, 98])),
+        (np.arange(6, 96), np.array([96, 97, 98, 99])),
+    ]
+
+    # should be 7
+    for i, (train, test) in enumerate(gen):
+        assert_array_equal(train, expected[i][0])
+        assert_array_equal(test, expected[i][1])
+
+    # assert no extra splits
+    with pytest.raises(StopIteration):
+        next(gen)


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

This PR fixes the upper bound in our `range` as called out in #364. Should unblock #369

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit tests

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
