### PR TITLE
[MAINT+1] Use setup-python v2 everywhere

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@master
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
           architecture: 'x64'
       - name: Install Requirements
         run: python -m pip install requests

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -43,7 +43,7 @@ jobs:
         shell: powershell
 
       - name: Setting up Python
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}

--- a/.github/workflows/test_tagging.yml
+++ b/.github/workflows/test_tagging.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setting up Python
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           architecture: 'x64'
 
       - name: Ensure VERSION tagging works


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

`setup-python@v1` uses a deprecated feature of github actions, so I am bumping to v2. Additionally, I am using 3.8 everywhere where we specify a version (`test tagging` and `update badges`)


## Type of change

- [X] CI/CD Maintenance

# How Has This Been Tested?

- [X] GH Actions still works 🤷🏻‍♂️ 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
