### PR TITLE
[MRG] Allow everything except setuptools 50.0.0

### DIFF
--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -8,7 +8,7 @@ patsy
 pytest
 pytest-mpl
 pytest-benchmark
-setuptools>=38.6.0,<50.0.0
+setuptools>=38.6.0,!=50.0.0
 wheel
 twine>=1.13.0
 readme_renderer

--- a/build_tools/circle/build_manylinux_wheel.sh
+++ b/build_tools/circle/build_manylinux_wheel.sh
@@ -10,7 +10,7 @@ PIP="/opt/python/${PYTHON_VERSION}/bin/pip"
 # We have to use wheel < 0.32 since they inexplicably removed the open_for_csv
 # function from the package after 0.31.1 and it fails for Python 3.6?!
 ${PIP} install --upgrade pip wheel==0.31.1
-${PIP} install --upgrade "setuptools<50.0.0"
+${PIP} install --upgrade "setuptools>=38.6.0,!=50.0.0"
 ${PIP} install --upgrade cython
 ${PIP} install --upgrade numpy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ scikit-learn>=0.22
 scipy>=1.3.2
 statsmodels>=0.11,!=0.12.0
 urllib3
-setuptools<50.0.0
+setuptools>=38.6.0,!=50.0.0


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

We pinned setuptools to `<50.0.0` in #379 due to the issue noted in https://github.com/pypa/setuptools/issues/2356. It seems to only affect v50.0.0, and we never forgot to unpin it. It is now causing issues (See #401). I think this should alleviate that.

## Type of change

- [X] Dependency fix

# How Has This Been Tested?

- [x] Unit tests pass

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
