### PR TITLE
[MRG+2] Add fix for issue#370 to allow iterables

### DIFF
--- a/build_tools/circle/deploy_doc.sh
+++ b/build_tools/circle/deploy_doc.sh
@@ -45,15 +45,15 @@ ls -la
 # On both of these, we'll need to remove the artifacts from the package
 # build itself. The _configtest files are added in the latest version of
 # numpy...
-declare -a leftover=("benchmarks"
+declare -a leftover=("_configtest"
+                     "_configtest.c"
+                     "_configtest.o"
+                     "benchmarks"
                      "build"
                      "dist"
                      "doc"
                      "pmdarima"
-                     "pmdarima.egg-info"
-                     "_configtest"
-                     "_configtest.c"
-                     "_configtest.o")
+                     "pmdarima.egg-info")
 
 # check for each left over file/dir and remove it
 for left in "${leftover[@]}"
@@ -91,6 +91,7 @@ else
                         "auto_examples"
                         "includes"
                         "modules"
+                        "rfc"
                         "usecases")
 
   for artifact in "${artifacts[@]}"

--- a/pmdarima/compat/statsmodels.py
+++ b/pmdarima/compat/statsmodels.py
@@ -2,6 +2,7 @@
 #
 # Handle inconsistencies in the statsmodels API versions
 
+from collections import abc
 from pkg_resources import parse_version
 import statsmodels as sm
 
@@ -45,8 +46,18 @@ def check_seasonal_order(order):
     order : tuple
         The existing seasonal order
     """
-    if sum(order[:3]) == 0 and order[-1] == 1:
-        order = (0, 0, 0, 0)
+
+    try:
+        # Assume an iterable for order[0].
+        # If order[0] is then we don't perform check.
+        # issue#370: https://github.com/alkaline-ml/pmdarima/issues/370
+        for _ in order[0]:
+            pass
+        return order
+    except TypeError:
+        # If order[0] is not iterable we perform the check
+        if sum(order[:3]) == 0 and order[-1] == 1:
+            order = (0, 0, 0, 0)
 
     # user's order may still be invalid, but we'll let statsmodels' validation
     # handle that.

--- a/pmdarima/compat/statsmodels.py
+++ b/pmdarima/compat/statsmodels.py
@@ -2,7 +2,6 @@
 #
 # Handle inconsistencies in the statsmodels API versions
 
-from collections import abc
 from pkg_resources import parse_version
 import statsmodels as sm
 

--- a/pmdarima/compat/statsmodels.py
+++ b/pmdarima/compat/statsmodels.py
@@ -2,6 +2,7 @@
 #
 # Handle inconsistencies in the statsmodels API versions
 
+from collections.abc import Iterable
 from pkg_resources import parse_version
 import statsmodels as sm
 
@@ -46,18 +47,15 @@ def check_seasonal_order(order):
         The existing seasonal order
     """
 
-    try:
-        # Assume an iterable for order[0].
-        # If order[0] is then we don't perform check.
-        # issue#370: https://github.com/alkaline-ml/pmdarima/issues/370
-        for _ in order[0]:
-            pass
+    # If order[0] is an iterable, but not a string then we don't perform check.
+    # Otherwise we perform the check and override order if it satisfies check.
+    # See issue#370: https://github.com/alkaline-ml/pmdarima/issues/370
+    if isinstance(order[0], Iterable) and not isinstance(order[0], str):
         return order
-    except TypeError:
-        # If order[0] is not iterable we perform the check
+    else:
         if sum(order[:3]) == 0 and order[-1] == 1:
             order = (0, 0, 0, 0)
 
-    # user's order may still be invalid, but we'll let statsmodels' validation
-    # handle that.
-    return order
+        # user's order may be invalid, but we'll let statsmodels' validation
+        # handle that.
+        return order

--- a/pmdarima/compat/tests/test_statsmodels.py
+++ b/pmdarima/compat/tests/test_statsmodels.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from pmdarima.compat.statsmodels import bind_df_model
+from pmdarima.compat.statsmodels import bind_df_model, check_seasonal_order
 
 
 # Test binding the degrees of freedom to a class in place. It's hard to test
@@ -28,3 +28,15 @@ def test_bind_df_model():
     # Now it should
     assert hasattr(res, 'df_model')
     assert res.df_model == 11, res.df_model
+
+
+def test_check_seasonal_order():
+    # issue370, using an iterable at position 0 returns
+    order = ([1, 2, 3, 52], 0, 1, 7)
+    checked_order = check_seasonal_order(order)
+    assert order == checked_order
+
+    # Special case where we override the seasonal order that is passed in.
+    order = (0, 0, 0, 1)
+    checked_order = check_seasonal_order(order)
+    assert checked_order == (0, 0, 0, 0)


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

This PR addresses the compatibility check not allowing iterables in position 0 of the the seasonal_order tuple as pointed out in #370. It first assumes an iterable at position 0 (trying to be pythonic :)), and if it iterable we return unmodified. We only override the order in the special case of `(0,0,0,1)`. Additional changes were made to add test cases to check the special case of the override and the iterable not raising a `TypeError`.

Fixes #370 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes [issue#370](https://github.com/alkaline-ml/pmdarima/issues/370))

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Please also list any relevant details
for your test configuration

- [x] Add test for `pmdarima.compat.statsmodels.check_seasonal_order`

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [`N/A`] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
