### PR TITLE
[MRG+1] Override env for mac builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,9 +129,10 @@ cmdclass = {'clean': CleanCommand}
 
 # build_ext has to be imported after setuptools
 try:
+    import numpy as np
     from numpy.distutils.command.build_ext import build_ext  # noqa
 
-    if sys.platform == 'darwin':
+    if sys.platform == 'darwin' and np.__version__ >= '1.20.0':
         os.environ['NPY_BLAS_ORDER'] = ''
         os.environ['NPY_LAPACK_ORDER'] = ''
 

--- a/setup.py
+++ b/setup.py
@@ -130,9 +130,11 @@ cmdclass = {'clean': CleanCommand}
 # build_ext has to be imported after setuptools
 try:
     import numpy as np
+    import numpy.lib.NumpyVersion
     from numpy.distutils.command.build_ext import build_ext  # noqa
 
-    if sys.platform == 'darwin' and np.__version__ >= '1.20.0':
+    # This is the preferred way to check numpy version: https://git.io/JtEIb
+    if sys.platform == 'darwin' and NumpyVersion(np.__version__) >= '1.20.0':
         os.environ['NPY_BLAS_ORDER'] = ''
         os.environ['NPY_LAPACK_ORDER'] = ''
 

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,10 @@ cmdclass = {'clean': CleanCommand}
 try:
     from numpy.distutils.command.build_ext import build_ext  # noqa
 
+    if sys.platform == 'darwin':
+        os.environ['NPY_BLAS_ORDER'] = ''
+        os.environ['NPY_LAPACK_ORDER'] = ''
+
     class build_ext_subclass(build_ext):
         def build_extensions(self):
             build_ext.build_extensions(self)

--- a/setup.py
+++ b/setup.py
@@ -130,11 +130,11 @@ cmdclass = {'clean': CleanCommand}
 # build_ext has to be imported after setuptools
 try:
     import numpy as np
-    import numpy.lib.NumpyVersion
     from numpy.distutils.command.build_ext import build_ext  # noqa
 
     # This is the preferred way to check numpy version: https://git.io/JtEIb
-    if sys.platform == 'darwin' and NumpyVersion(np.__version__) >= '1.20.0':
+    if sys.platform == 'darwin' and np.lib.NumpyVersion(np.__version__) >= '1.20.0':
+        # https://numpy.org/devdocs/user/building.html#disabling-atlas-and-other-accelerated-libraries
         os.environ['NPY_BLAS_ORDER'] = ''
         os.environ['NPY_LAPACK_ORDER'] = ''
 


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

The nightly build has been failing for macOS because numpy 1.2.0 (released 2021-01-30) deprecates some native libraries on macOS. This PR aims to address those concerns by following the numpy docs [here](https://numpy.org/devdocs/user/building.html#lapack)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] macOS builds work on CI/CD

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
