### PR TITLE
[MRG+1] Fix bug related to window_start index in RollingForecastCV. Fix the t…

### DIFF
--- a/pmdarima/model_selection/_split.py
+++ b/pmdarima/model_selection/_split.py
@@ -243,14 +243,14 @@ class RollingForecastCV(BaseTSCrossValidator):
         # guarantee that the forecasting horizon will not over-index the series
         all_indices = np.arange(n_samples)
         window_start = 0
+        window_end = initial
         while True:
-            window_end = window_start + initial
             if window_end + h > n_samples:
                 break
 
             train_indices = all_indices[window_start: window_end]
             test_indices = all_indices[window_end: window_end + h]
-            window_start += step
+            window_end += step
 
             yield train_indices, test_indices
 

--- a/pmdarima/model_selection/tests/test_split.py
+++ b/pmdarima/model_selection/tests/test_split.py
@@ -136,12 +136,12 @@ def test_rolling_forecast_cv_bad_splits():
 
     expected = [
         (np.arange(0, 90), np.array([90, 91, 92, 93])),
-        (np.arange(1, 91), np.array([91, 92, 93, 94])),
-        (np.arange(2, 92), np.array([92, 93, 94, 95])),
-        (np.arange(3, 93), np.array([93, 94, 95, 96])),
-        (np.arange(4, 94), np.array([94, 95, 96, 97])),
-        (np.arange(5, 95), np.array([95, 96, 97, 98])),
-        (np.arange(6, 96), np.array([96, 97, 98, 99])),
+        (np.arange(0, 91), np.array([91, 92, 93, 94])),
+        (np.arange(0, 92), np.array([92, 93, 94, 95])),
+        (np.arange(0, 93), np.array([93, 94, 95, 96])),
+        (np.arange(0, 94), np.array([94, 95, 96, 97])),
+        (np.arange(0, 95), np.array([95, 96, 97, 98])),
+        (np.arange(0, 96), np.array([96, 97, 98, 99])),
     ]
 
     # should be 7

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,14 @@ cmdclass = {'clean': CleanCommand}
 
 # build_ext has to be imported after setuptools
 try:
+    import numpy as np
     from numpy.distutils.command.build_ext import build_ext  # noqa
+
+    # This is the preferred way to check numpy version: https://git.io/JtEIb
+    if sys.platform == 'darwin' and np.lib.NumpyVersion(np.__version__) >= '1.20.0':
+        # https://numpy.org/devdocs/user/building.html#disabling-atlas-and-other-accelerated-libraries
+        os.environ['NPY_BLAS_ORDER'] = ''
+        os.environ['NPY_LAPACK_ORDER'] = ''
 
     class build_ext_subclass(build_ext):
         def build_extensions(self):


### PR DESCRIPTION
…est related to this class that also had a bug.

<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Fixes the issue with the start index for RollingForecastCV. Currently, RollingForecastCV behaves like SlidingWindowForecastCV. This minor fix restores the intended functionality.

Fixes #412 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This issue wasn't detected by the unit test (see the changed test) since the expected cases in the test for RollingForecastCV seem to be for SlidingWindowForecastCV. The corresponding test has been fixed and the unit tests run without errors.

- [x] Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
