### PR TITLE
[MRG+1] Fix bash syntax and update manylinux container

### DIFF
--- a/build_tools/circle/build_wheel.sh
+++ b/build_tools/circle/build_wheel.sh
@@ -9,7 +9,7 @@ function build_wheel {
 
     # https://www.python.org/dev/peps/pep-0513/#ucs-2-vs-ucs-4-builds
     ucs_tag="m"
-    if [ "$pyver" = "3.8"  || "$pyver" = "3.9" ]; then
+    if [ "$pyver" = "3.8" ] || [ "$pyver" = "3.9" ]; then
         ucs_tag=""
     elif [ "$ucs_setting" = "ucs4" ]; then
         ucs_tag="${ucs_tag}u"

--- a/build_tools/circle/build_wheel.sh
+++ b/build_tools/circle/build_wheel.sh
@@ -23,8 +23,7 @@ function build_wheel {
 
     DOCKER_CONTAINER_NAME=wheel_builder_$(uuidgen)
 
-    # Pin this image because wheel versions in later tags conflict
-    ML_IMAGE="quay.io/pypa/manylinux1_${arch}:2020-01-31-d8fa357"
+    ML_IMAGE="quay.io/pypa/manylinux1_${arch}:2021-04-10-43e4a61" # `latest` as of 2021-04-18
     PMDARIMA_VERSION=`cat ~/pmdarima/pmdarima/VERSION`
 
     docker pull "${ML_IMAGE}"


### PR DESCRIPTION
# Description

We had trouble deploying `1.8.1` for `3.8` and `3.9` because of this bad bash syntax. This should fix those deploys going forward (assuming we don't rewrite it first). Additionally, it updates our circle job to use a later version of the `manylinux` container to have Python 3.9 installed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Tested via SSH on Circle

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
