### PR TITLE
[MRG] (ISSUE-423) Update build_requirements 

### DIFF
--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.20.0
+numpy>=1.20.2
 scipy>=1.3.2
 cython>=0.29,!=0.29.18
 scikit-learn>=0.22

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -1,4 +1,4 @@
-numpy=1.20.2
+numpy==1.20.2
 scipy>=1.3.2
 cython>=0.29,!=0.29.18
 scikit-learn>=0.22

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.17.3
+numpy>=1.20.0
 scipy>=1.3.2
 cython>=0.29,!=0.29.18
 scikit-learn>=0.22

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.20.2
+numpy
 scipy>=1.3.2
 cython>=0.29,!=0.29.18
 scikit-learn>=0.22

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.20.2
+numpy=1.20.2
 scipy>=1.3.2
 cython>=0.29,!=0.29.18
 scikit-learn>=0.22


### PR DESCRIPTION
Updated the numpy version to fix installation issues

<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

pmdarima is not importing on version 1.8.1 
Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I built the latest version of pmdarima==1.8.1

by upgrading numpy and with the following versions for these packages

`   pip: 20.2.4
    setuptools: 50.3.1
    sklearn: 0.23.2
    statsmodels: 0.12.2
    numpy: 1.20.2
    scipy: 1.5.2
    Cython: 0.29.21
    pandas: 1.1.3
    joblib: 0.17.0
   pmdarima: 1.8.1`



# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
#423 