### PR TITLE
[MRG] Change numpy pin to allow versions greater than 1.19.X

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
 
           # we'll need numpy and cython to build this. let install_requires do all the
           # rest of the work. We build with our lowest supported numpy version to make sure there is no regression
-          pip install "numpy~=1.19.4" "cython>=0.29,!=0.29.18"
+          pip install "numpy~=1.19.3" "cython>=0.29,!=0.29.18"
           python setup.py sdist
 
           cd dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ jobs:
           echo "0.0.0" > ~/pmdarima/pmdarima/VERSION
 
           # we'll need numpy and cython to build this. let install_requires do all the
-          # rest of the work.
-          pip install "numpy~=1.19.0" "cython>=0.29,!=0.29.18"
+          # rest of the work. We build with our lowest supported numpy version to make sure there is no regression
+          pip install "numpy~=1.19.4" "cython>=0.29,!=0.29.18"
           python setup.py sdist
 
           cd dist

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -71,15 +71,15 @@ jobs:
       - name: Preinstalling Cython, numpy, and scipy (Windows only)
         if: startsWith(runner.os, 'Windows')
         run: |
-          pip install "$(cat requirements.txt | grep Cython)"
-          pip install "$(cat requirements.txt | grep numpy)"
-          pip install "$(cat requirements.txt | grep scipy)"
+          pip install "$(cat build_tools/build_requirements.txt | grep cython)"
+          pip install "$(cat build_tools/build_requirements.txt | grep numpy)"
+          pip install "$(cat build_tools/build_requirements.txt | grep scipy)"
         shell: bash
 
       - name: Installing requirements
         run: |
-          pip install -r requirements.txt
           pip install -r build_tools/build_requirements.txt
+          pip install -r requirements.txt
         shell: bash
 
       # We build the source archive separately because of this: https://github.com/alkaline-ml/pmdarima/pull/136#discussion_r279781731
@@ -103,6 +103,14 @@ jobs:
           fi
           pytest --showlocals --durations=20 --pyargs pmdarima --benchmark-skip
         shell: bash
+
+      - name: Checking for numpy regression
+        run: |
+          pip install --upgrade numpy
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+            export PMD_MPL_BACKEND=TkAgg
+          fi
+          pytest --showlocals --durations=20 --pyargs pmdarima --benchmark-skip
 
       - name: Checking README compatibility
         run: |

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -23,6 +23,9 @@ jobs:
           # Don't build 32-bit on Mac
           - os: macos-latest
             architecture: x86
+    defaults:
+      run:
+        shell: bash
 
     runs-on: ${{ matrix.os }}
 
@@ -65,7 +68,6 @@ jobs:
 
       - name: Updating pip
         run: python -m pip install --upgrade pip
-        shell: bash
 
       # statsmodels throws a fit on Windows and Python 3.8 if we don't preinstall these
       - name: Preinstalling Cython, numpy, and scipy (Windows only)
@@ -74,27 +76,22 @@ jobs:
           pip install "$(cat build_tools/build_requirements.txt | grep cython)"
           pip install "$(cat build_tools/build_requirements.txt | grep numpy)"
           pip install "$(cat build_tools/build_requirements.txt | grep scipy)"
-        shell: bash
 
       - name: Installing requirements
         run: |
           pip install -r build_tools/build_requirements.txt
           pip install -r requirements.txt
-        shell: bash
 
       # We build the source archive separately because of this: https://github.com/alkaline-ml/pmdarima/pull/136#discussion_r279781731
       # We build it first because of this: https://github.com/alkaline-ml/pmdarima/issues/448
       - name: Building source distribution
         run: make version sdist
-        shell: bash
 
       - name: Building wheel
         run: make version bdist_wheel
-        shell: bash
 
       - name: Installing generated wheel
         run: pip install --pre --no-index --find-links dist/ pmdarima
-        shell: bash
 
       - name: Running unit tests
         run: |
@@ -102,7 +99,6 @@ jobs:
             export PMD_MPL_BACKEND=TkAgg
           fi
           pytest --showlocals --durations=20 --pyargs pmdarima --benchmark-skip
-        shell: bash
 
       - name: Checking for numpy regression
         run: |
@@ -120,7 +116,6 @@ jobs:
           else
               echo "README rendered appropriately"
           fi
-        shell: bash
 
       # See https://github.com/alkaline-ml/pmdarima/issues/448
       - name: Ensuring sdist SOURCES.txt has no absolute paths
@@ -136,11 +131,9 @@ jobs:
             echo "SOURCES.txt looks good"
             rm -rf "$OUTPUT_DIRECTORY"
           fi
-        shell: bash
 
       - name: Ensuring sdist can be installed
         run: pip install dist/$(ls dist | grep tar)
-        shell: bash
 
       - name: Ensuring VERSION file existis
         id: version_check  # Need this to refer to output below
@@ -152,7 +145,6 @@ jobs:
             echo "VERSION file does not exist"
             echo "::set-output name=version_exists::false"
           fi
-        shell: bash
 
       - name: Deploying to PyPI
         # Only deploy on tags and when VERSION file created
@@ -160,7 +152,6 @@ jobs:
         run: |
           chmod +x build_tools/github/deploy.sh
           ./build_tools/github/deploy.sh
-        shell: bash
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -1,4 +1,4 @@
-numpy~=1.19.0
+numpy~=1.19.4
 scipy>=1.3.2
 cython>=0.29,!=0.29.18
 scikit-learn>=0.22

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -2,7 +2,7 @@ numpy~=1.19.3
 scipy>=1.3.2
 cython>=0.29,!=0.29.18
 scikit-learn>=0.22
-pandas>=0.19
+pandas>=1.0
 statsmodels>=0.11,!=0.12.0
 patsy
 pytest

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -1,4 +1,4 @@
-numpy~=1.19.4
+numpy~=1.19.3
 scipy>=1.3.2
 cython>=0.29,!=0.29.18
 scikit-learn>=0.22

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -2,7 +2,7 @@ numpy~=1.19.3
 scipy>=1.3.2
 cython>=0.29,!=0.29.18
 scikit-learn>=0.22
-pandas>=1.0
+pandas>=0.19
 statsmodels>=0.11,!=0.12.0
 patsy
 pytest

--- a/build_tools/circle/build_wheel.sh
+++ b/build_tools/circle/build_wheel.sh
@@ -23,7 +23,7 @@ function build_wheel {
 
     DOCKER_CONTAINER_NAME=wheel_builder_$(uuidgen)
 
-    ML_IMAGE="quay.io/pypa/manylinux1_${arch}:2021-04-10-43e4a61" # `latest` as of 2021-04-18
+    ML_IMAGE="quay.io/pypa/manylinux_2_24_${arch}:2021-08-29-ad54d32" # `latest` as of 2021-08-30
     PMDARIMA_VERSION=`cat ~/pmdarima/pmdarima/VERSION`
 
     docker pull "${ML_IMAGE}"

--- a/build_tools/circle/dind/build_manylinux_wheel.sh
+++ b/build_tools/circle/dind/build_manylinux_wheel.sh
@@ -15,6 +15,7 @@ ${PIP} install --upgrade pip wheel==0.31.1
 ${PIP} install --upgrade "setuptools>=38.6.0,!=50.0.0"
 
 # NOW we can install requirements
+${PIP} install -r /io/build_tools/build_requirements.txt # Install these first because they are more restrictive
 ${PIP} install -r /io/requirements.txt
 make -C /io/ PYTHON="${PYTHON}"
 

--- a/build_tools/circle/dind/build_manylinux_wheel.sh
+++ b/build_tools/circle/dind/build_manylinux_wheel.sh
@@ -15,7 +15,7 @@ ${PIP} install --upgrade pip wheel==0.31.1
 ${PIP} install --upgrade "setuptools>=38.6.0,!=50.0.0"
 
 # NOW we can install requirements
-${PIP} install "numpy~=1.19.3"
+${PIP} install -r /io/build_tools/build_requirements.txt
 ${PIP} install -r /io/requirements.txt
 make -C /io/ PYTHON="${PYTHON}"
 

--- a/build_tools/circle/dind/build_manylinux_wheel.sh
+++ b/build_tools/circle/dind/build_manylinux_wheel.sh
@@ -15,7 +15,7 @@ ${PIP} install --upgrade pip wheel==0.31.1
 ${PIP} install --upgrade "setuptools>=38.6.0,!=50.0.0"
 
 # NOW we can install requirements
-${PIP} install -r /io/build_tools/build_requirements.txt # Install these first because they are more restrictive
+${PIP} install "numpy~=1.19.3"
 ${PIP} install -r /io/requirements.txt
 make -C /io/ PYTHON="${PYTHON}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 joblib>=0.11
 Cython>=0.29,!=0.29.18
 numpy>=1.19.3
-pandas>=1.0
+pandas>=0.19
 scikit-learn>=0.22
 scipy>=1.3.2
 statsmodels>=0.11,!=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 joblib>=0.11
 Cython>=0.29,!=0.29.18
 numpy>=1.19.3
-pandas>=0.19
+pandas>=1.0
 scikit-learn>=0.22
 scipy>=1.3.2
 statsmodels>=0.11,!=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 joblib>=0.11
 Cython>=0.29,!=0.29.18
-numpy~=1.19.0
+numpy>=1.19.4
 pandas>=0.19
 scikit-learn>=0.22
 scipy>=1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 joblib>=0.11
 Cython>=0.29,!=0.29.18
-numpy>=1.19.4
+numpy>=1.19.3
 pandas>=0.19
 scikit-learn>=0.22
 scipy>=1.3.2


### PR DESCRIPTION
# Description

This PR updates our `numpy` pin in two ways:

- It changes it in `requirements.txt` to be `numpy>=1.9.3` (undoing the `~=` pin and increasing the minimum version)
  - The minimum version bump was because that was the first release that includes wheels for all the versions of Python we support
- It changes it in `build_tools/build_requirements.txt` to be `numpy~1.193`. The hope is we build on our minimum supported version and don't limit users in `requirements.txt`

It also updates CI/CD to use `build_tools/build_requirements.txt` where necessary and adds a regression check in GitHub Actions (@tgsmith61591 may need your help if you want a similar check in Circle)

Fixes #449 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Dependency change

# How Has This Been Tested?

If you look at #425, you'll remember we broke `sktime` last time we tried to do this. I believe that is because we built with a greater version of numpy than they were using. Here is how I test it this time (I use `$` for a local shell and `>` for a shell in Docker). I used Python 3.8 because that is the max version `sktime` currently supports.

```
$ docker run -it -v $(pwd):/home/pmdarima -w /home python:3.8-slim /bin/bash
> apt-get update && apt-get -y install make gcc
> pip install -r pmdarima/build_tools/build_requirements.txt
> pip freeze
attrs==21.2.0
bleach==4.1.0
certifi==2021.5.30
cffi==1.14.6
charset-normalizer==2.0.4
colorama==0.4.4
cryptography==3.4.8
cycler==0.10.0
Cython==0.29.24
docutils==0.17.1
idna==3.2
importlib-metadata==4.8.1
iniconfig==1.1.1
jeepney==0.7.1
joblib==1.0.1
keyring==23.1.0
kiwisolver==1.3.2
matplotlib==3.4.3
numpy==1.19.5
packaging==21.0
pandas==1.3.2
patsy==0.5.1
Pillow==8.3.1
pkginfo==1.7.1
pluggy==0.13.1
py==1.10.0
py-cpuinfo==8.0.0
pycparser==2.20
Pygments==2.10.0
pyparsing==2.4.7
pytest==6.2.4
pytest-benchmark==3.4.1
pytest-mpl==0.13
python-dateutil==2.8.2
pytz==2021.1
readme-renderer==29.0
requests==2.26.0
requests-toolbelt==0.9.1
rfc3986==1.5.0
scikit-learn==0.24.2
scipy==1.7.1
SecretStorage==3.3.1
six==1.16.0
statsmodels==0.12.2
threadpoolctl==2.2.0
toml==0.10.2
tqdm==4.62.2
twine==3.4.2
urllib3==1.26.6
webencodings==0.5.1
zipp==3.5.0
> pip install sktime pmdarima
> python -c 'import sktime; import pmdarima; sktime.show_versions(); pmdarima.show_versions()'

System:
    python: 3.8.11 (default, Aug 17 2021, 02:56:00)  [GCC 10.2.1 20210110]
executable: /usr/local/bin/python
   machine: Linux-5.10.47-linuxkit-x86_64-with-glibc2.2.5

Python dependencies:
          pip: 21.2.4
   setuptools: 57.4.0
      sklearn: 0.24.2
       sktime: 0.7.0
  statsmodels: 0.12.2
        numpy: 1.19.5
        scipy: 1.7.1
       Cython: 0.29.24
       pandas: 1.3.2
   matplotlib: 3.4.3
       joblib: 1.0.1
        numba: 0.54.0
     pmdarima: 1.8.2
      tsfresh: None

System:
    python: 3.8.11 (default, Aug 17 2021, 02:56:00)  [GCC 10.2.1 20210110]
executable: /usr/local/bin/python
   machine: Linux-5.10.47-linuxkit-x86_64-with-glibc2.2.5

Python dependencies:
        pip: 21.2.4
 setuptools: 57.4.0
    sklearn: 0.24.2
statsmodels: 0.12.2
      numpy: 1.19.5
      scipy: 1.7.1
     Cython: 0.29.24
     pandas: 1.3.2
     joblib: 1.0.1
   pmdarima: 1.8.2
> pip uninstall -y pmdarima
> cd pmdarima
> echo "1.8.3dev0" > pmdarima/VERSION
> make bdist_wheel
> pip install dist/*
> pip freeze | grep pmdarima
pmdarima @ file:///home/pmdarima/dist/pmdarima-1.8.3.dev0-cp38-cp38-linux_x86_64.whl
> pytest --showlocals --durations=20 --pyargs pmdarima --benchmark-skip
...
444 passed, 1700 warnings in 98.27s (0:01:38)
> cd ..
> python -c 'import sktime; import pmdarima; sktime.show_versions(); pmdarima.show_versions()'

System:
    python: 3.8.11 (default, Aug 17 2021, 02:56:00)  [GCC 10.2.1 20210110]
executable: /usr/local/bin/python
   machine: Linux-5.10.47-linuxkit-x86_64-with-glibc2.2.5

Python dependencies:
          pip: 21.2.4
   setuptools: 57.4.0
      sklearn: 0.24.2
       sktime: 0.7.0
  statsmodels: 0.12.2
        numpy: 1.19.5
        scipy: 1.7.1
       Cython: 0.29.24
       pandas: 1.3.2
   matplotlib: 3.4.3
       joblib: 1.0.1
        numba: 0.54.0
     pmdarima: 1.8.3dev0
      tsfresh: None

System:
    python: 3.8.11 (default, Aug 17 2021, 02:56:00)  [GCC 10.2.1 20210110]
executable: /usr/local/bin/python
   machine: Linux-5.10.47-linuxkit-x86_64-with-glibc2.2.5

Python dependencies:
        pip: 21.2.4
 setuptools: 57.4.0
    sklearn: 0.24.2
statsmodels: 0.12.2
      numpy: 1.19.5
      scipy: 1.7.1
     Cython: 0.29.24
     pandas: 1.3.2
     joblib: 1.0.1
   pmdarima: 1.8.3dev0
> pip install --upgrade numpy
> python -c 'import sktime; import pmdarima; sktime.show_versions(); pmdarima.show_versions()'

System:
    python: 3.8.11 (default, Aug 17 2021, 02:56:00)  [GCC 10.2.1 20210110]
executable: /usr/local/bin/python
   machine: Linux-5.10.47-linuxkit-x86_64-with-glibc2.2.5

Python dependencies:
          pip: 21.2.4
   setuptools: 57.4.0
      sklearn: 0.24.2
       sktime: 0.7.0
  statsmodels: 0.12.2
        numpy: 1.21.2
        scipy: 1.7.1
       Cython: 0.29.24
       pandas: 1.3.2
   matplotlib: 3.4.3
       joblib: 1.0.1
        numba: None
     pmdarima: 1.8.3dev0
      tsfresh: None

System:
    python: 3.8.11 (default, Aug 17 2021, 02:56:00)  [GCC 10.2.1 20210110]
executable: /usr/local/bin/python
   machine: Linux-5.10.47-linuxkit-x86_64-with-glibc2.2.5

Python dependencies:
        pip: 21.2.4
 setuptools: 57.4.0
    sklearn: 0.24.2
statsmodels: 0.12.2
      numpy: 1.21.2
      scipy: 1.7.1
     Cython: 0.29.24
     pandas: 1.3.2
     joblib: 1.0.1
   pmdarima: 1.8.3dev0
> cd pmdarima
> pytest --showlocals --durations=20 --pyargs pmdarima --benchmark-skip
...
444 passed, 1700 warnings in 90.19s (0:01:30)
```

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
