### PR TITLE
[MRG+1] Add compatibility for statsmodels 0.13 and higher

### DIFF
--- a/pmdarima/compat/statsmodels.py
+++ b/pmdarima/compat/statsmodels.py
@@ -59,3 +59,7 @@ def check_seasonal_order(order):
         # user's order may be invalid, but we'll let statsmodels' validation
         # handle that.
         return order
+
+
+def _use_sm13():
+    return parse_version(sm.__version__) >= parse_version("0.13.0")

--- a/pmdarima/utils/tests/test_wrapped.py
+++ b/pmdarima/utils/tests/test_wrapped.py
@@ -7,6 +7,7 @@ import statsmodels.api as sm
 import numpy as np
 
 import pytest
+from unittest import mock
 
 y = pm.datasets.load_wineind()
 
@@ -23,3 +24,22 @@ def test_wrapped_functions(wrapped_func, native_func):
 
     # Show the docstrings are the same
     assert wrapped_func.__doc__ == native_func.__doc__
+
+
+@pytest.mark.parametrize("use_sm13", [True, False])
+def test_statsmodels13_compatibility(use_sm13):
+    with mock.patch("pmdarima.compat.statsmodels._use_sm13") as mock_sm:
+        mock_sm.return_value = use_sm13
+
+        wrapped_acf_result = acf(y)
+        wrapped_pacf_result = pacf(y)
+
+        if use_sm13:
+            native_acf_result = sm.tsa.stattools.acf(y)
+            native_pacf_result = sm.tsa.stattools.pacf(y)
+        else:
+            native_acf_result = sm.tsa.stattools.acf(y, nlags=40, fft=False)
+            native_pacf_result = sm.tsa.stattools.pacf(y, nlags=40)
+
+        assert np.allclose(wrapped_acf_result, native_acf_result)
+        assert np.allclose(wrapped_pacf_result, native_pacf_result)

--- a/pmdarima/utils/tests/test_wrapped.py
+++ b/pmdarima/utils/tests/test_wrapped.py
@@ -7,7 +7,6 @@ import statsmodels.api as sm
 import numpy as np
 
 import pytest
-from unittest import mock
 
 y = pm.datasets.load_wineind()
 
@@ -24,22 +23,3 @@ def test_wrapped_functions(wrapped_func, native_func):
 
     # Show the docstrings are the same
     assert wrapped_func.__doc__ == native_func.__doc__
-
-
-@pytest.mark.parametrize("use_sm13", [True, False])
-def test_statsmodels13_compatibility(use_sm13):
-    with mock.patch("pmdarima.compat.statsmodels._use_sm13") as mock_sm:
-        mock_sm.return_value = use_sm13
-
-        wrapped_acf_result = acf(y)
-        wrapped_pacf_result = pacf(y)
-
-        if use_sm13:
-            native_acf_result = sm.tsa.stattools.acf(y)
-            native_pacf_result = sm.tsa.stattools.pacf(y)
-        else:
-            native_acf_result = sm.tsa.stattools.acf(y, nlags=40, fft=False)
-            native_pacf_result = sm.tsa.stattools.pacf(y, nlags=40)
-
-        assert np.allclose(wrapped_acf_result, native_acf_result)
-        assert np.allclose(wrapped_pacf_result, native_pacf_result)

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -58,7 +58,7 @@ def inheritdoc(parent):
 
 
 @inheritdoc(parent=sm_acf)
-def acf(x, unbiased=None, nlags=None, qstat=False, fft=True,
+def acf(x, unbiased=None, nlags=None, qstat=False, fft=None,
         alpha=None, missing='none', adjusted=False):
     kwargs = {
         "x": x,
@@ -80,6 +80,8 @@ def acf(x, unbiased=None, nlags=None, qstat=False, fft=True,
             kwargs["adjusted"] = unbiased
         else:
             kwargs["adjusted"] = adjusted
+
+        kwargs["fft"] = fft or True
     else:
         kwargs["nlags"] = nlags or 40  # Becomes `None` in 0.13.0
         kwargs["fft"] = fft or False  # Becomes `True` in 0.13.0

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -3,10 +3,12 @@
 # Taylor G Smith <taylor.smith@alkaline.ml>
 #
 # Wrapped functions
+from functools import wraps
+from pkg_resources import parse_version
+import warnings
 
 from statsmodels.tsa.stattools import acf as sm_acf, pacf as sm_pacf
-
-from functools import wraps
+import statsmodels
 
 __all__ = [
     'acf',
@@ -54,13 +56,46 @@ def inheritdoc(parent):
 
 
 @inheritdoc(parent=sm_acf)
-def acf(x, unbiased=False, nlags=40, qstat=False, fft=False,
-        alpha=None, missing='none'):
-    return sm_acf(x=x, unbiased=unbiased, nlags=nlags,
-                  qstat=qstat, fft=fft, alpha=alpha,
-                  missing=missing)
+def acf(x, unbiased=None, nlags=40, qstat=False, fft=False,
+        alpha=None, missing='none', adjusted=False):
+    kwargs = {
+        "x": x,
+        "nlags": nlags,
+        "qstat": qstat,
+        "fft": fft,
+        "alpha": alpha,
+        "missing": missing,
+    }
+
+    # Handle kwarg deprecation in statsmodels 0.13.0
+    if parse_version(statsmodels.__version__) >= parse_version("0.13.0"):
+        if unbiased is not None:
+            warnings.warn(
+                "The `unbiased` key-word has been deprecated in "
+                "statsmodels >= 0.13.0. Please use `adjusted` instead.",
+                DeprecationWarning
+            )
+            kwargs["adjusted"] = unbiased
+        else:
+            kwargs["adjusted"] = adjusted
+    else:
+        if unbiased is not None:
+            kwargs["unbiased"] = unbiased
+        else:
+            kwargs["unbiased"] = adjusted
+
+    return sm_acf(**kwargs)
 
 
 @inheritdoc(parent=sm_pacf)
 def pacf(x, nlags=40, method='ywunbiased', alpha=None):
+    # Handle kwarg deprecation in statsmodels 0.13.0
+    if parse_version(statsmodels.__version__) >= parse_version("0.13.0") and "unbiased" in method:
+        warnings.warn(
+            "The `*unbiased` methods have been deprecated in "
+            "statsmodels >= 0.13.0. Please use `*adjusted` instead.",
+            DeprecationWarning
+        )
+        method = method.replace("unbiased", "adjusted")
+
     return sm_pacf(x=x, nlags=nlags, method=method, alpha=alpha)

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -112,6 +112,14 @@ def pacf(x, nlags=None, method='ywadjusted', alpha=None):
             )
             method = method.replace("u", "a")
     else:
-        nlags = 40
+        # Have to do the opposite of the above since we support statsmodels
+        # 0.11.0. 0.12.0 supports both `unbiased` and `adjusted`, but 0.11.0
+        # doesn't, so this works for anything < 0.13.0
+        if "adjusted" in method:
+            method = method.replace("adjusted", "unbiased")
+        elif method in ("yda", "ywa", "lda"):
+            method = method.replace("a", "w")
+
+        nlags = 40  # Becomes `None` in 0.13.0
 
     return sm_pacf(x=x, nlags=nlags, method=method, alpha=alpha)

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -93,7 +93,7 @@ def acf(x, unbiased=None, nlags=None, qstat=False, fft=True,
 
 
 @inheritdoc(parent=sm_pacf)
-def pacf(x, nlags=None, method='ywunbiased', alpha=None):
+def pacf(x, nlags=None, method='ywadjusted', alpha=None):
     # Handle kwarg deprecation in statsmodels 0.13.0
     if _use_sm13():
         if "unbiased" in method:

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -120,7 +120,7 @@ def pacf(x, nlags=None, method='ywadjusted', alpha=None):
         if "adjusted" in method:
             method = method.replace("adjusted", "unbiased")
         elif method in ("yda", "ywa", "lda"):
-            method = method.replace("a", "w")
+            method = method.replace("a", "u")
 
         nlags = nlags or 40  # Becomes `None` in 0.13.0
 

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -56,7 +56,7 @@ def inheritdoc(parent):
 
 
 @inheritdoc(parent=sm_acf)
-def acf(x, unbiased=None, nlags=40, qstat=False, fft=False,
+def acf(x, unbiased=None, nlags=None, qstat=False, fft=True,
         alpha=None, missing='none', adjusted=False):
     kwargs = {
         "x": x,
@@ -79,6 +79,9 @@ def acf(x, unbiased=None, nlags=40, qstat=False, fft=False,
         else:
             kwargs["adjusted"] = adjusted
     else:
+        kwargs["nlags"] = 40  # Becomes `None` in 0.13.0
+        kwargs["fft"] = False  # Becomes `True` in 0.13.0
+
         if unbiased is not None:
             kwargs["unbiased"] = unbiased
         else:

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -10,6 +10,8 @@ import warnings
 from statsmodels.tsa.stattools import acf as sm_acf, pacf as sm_pacf
 import statsmodels
 
+from pmdarima.compat.statsmodels import _use_sm13
+
 __all__ = [
     'acf',
     'pacf'
@@ -68,7 +70,7 @@ def acf(x, unbiased=None, nlags=None, qstat=False, fft=True,
     }
 
     # Handle kwarg deprecation in statsmodels 0.13.0
-    if parse_version(statsmodels.__version__) >= parse_version("0.13.0"):
+    if _use_sm13():
         if unbiased is not None:
             warnings.warn(
                 "The `unbiased` key-word has been deprecated in "
@@ -93,7 +95,7 @@ def acf(x, unbiased=None, nlags=None, qstat=False, fft=True,
 @inheritdoc(parent=sm_pacf)
 def pacf(x, nlags=None, method='ywunbiased', alpha=None):
     # Handle kwarg deprecation in statsmodels 0.13.0
-    if parse_version(statsmodels.__version__) >= parse_version("0.13.0"):
+    if _use_sm13():
         if "unbiased" in method:
             warnings.warn(
                 "The `*unbiased` methods have been deprecated in "

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -91,14 +91,25 @@ def acf(x, unbiased=None, nlags=None, qstat=False, fft=True,
 
 
 @inheritdoc(parent=sm_pacf)
-def pacf(x, nlags=40, method='ywunbiased', alpha=None):
+def pacf(x, nlags=None, method='ywunbiased', alpha=None):
     # Handle kwarg deprecation in statsmodels 0.13.0
-    if parse_version(statsmodels.__version__) >= parse_version("0.13.0") and "unbiased" in method:
-        warnings.warn(
-            "The `*unbiased` methods have been deprecated in "
-            "statsmodels >= 0.13.0. Please use `*adjusted` instead.",
-            DeprecationWarning
-        )
-        method = method.replace("unbiased", "adjusted")
+    if parse_version(statsmodels.__version__) >= parse_version("0.13.0"):
+        if "unbiased" in method:
+            warnings.warn(
+                "The `*unbiased` methods have been deprecated in "
+                "statsmodels >= 0.13.0. Please use `*adjusted` instead.",
+                DeprecationWarning
+            )
+            method = method.replace("unbiased", "adjusted")
+        elif method in ("ydu", "ywu", "ldu"):
+            warnings.warn(
+                "The `ydu`, `ywu`, and `ldu` methods have been deprecated in "
+                "statsmodels >= 0.13.0. Please use `yda`, `ywa`, and `lda` "
+                "instead.",
+                DeprecationWarning
+            )
+            method = method.replace("u", "a")
+    else:
+        nlags = 40
 
     return sm_pacf(x=x, nlags=nlags, method=method, alpha=alpha)

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -81,8 +81,8 @@ def acf(x, unbiased=None, nlags=None, qstat=False, fft=True,
         else:
             kwargs["adjusted"] = adjusted
     else:
-        kwargs["nlags"] = 40  # Becomes `None` in 0.13.0
-        kwargs["fft"] = False  # Becomes `True` in 0.13.0
+        kwargs["nlags"] = nlags or 40  # Becomes `None` in 0.13.0
+        kwargs["fft"] = fft or False  # Becomes `True` in 0.13.0
 
         if unbiased is not None:
             kwargs["unbiased"] = unbiased
@@ -120,6 +120,6 @@ def pacf(x, nlags=None, method='ywadjusted', alpha=None):
         elif method in ("yda", "ywa", "lda"):
             method = method.replace("a", "w")
 
-        nlags = 40  # Becomes `None` in 0.13.0
+        nlags = nlags or 40  # Becomes `None` in 0.13.0
 
     return sm_pacf(x=x, nlags=nlags, method=method, alpha=alpha)


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

This should fix the nightly build. The `unbiased` keyword and methods have been deprecated in `statsmodels` 0.13.0. A couple defaults for `acf` and `pacf` have also changed


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change

# How Has This Been Tested?

- [X] `test_wrapped` now works if testing with `statsmodels` 0.13.0

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
