### PR TITLE
[MRG+1] Switch to macos-10.15 instead of macos-latest

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -16,12 +16,12 @@ jobs:
     name: Build and Deploy
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, macos-10.15]
         python-version: ['3.6', '3.7', '3.8', '3.9']
         architecture: ['x86', 'x64']
         exclude:
           # Don't build 32-bit on Mac
-          - os: macos-latest
+          - os: macos-10.15
             architecture: x86
     defaults:
       run:
@@ -34,16 +34,6 @@ jobs:
       # It is actually checking out the most recent version on this branch
       - name: Checkout
         uses: actions/checkout@master
-
-      # Visual Studio 2019 (windows-latest) doesn't include these files for some reason??
-      # Even stranger, it really only affects Python 3.5, but we run it across all versions for consistency
-      # https://social.msdn.microsoft.com/Forums/vstudio/en-US/06675e6d-9a0b-46f5-8de0-10237fab1ece/link-error-lnk1158?forum=vcgeneral
-      - name: Fix Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          Copy-Item "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x86\rc.exe" -Destination "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN"
-          Copy-Item "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x86\rcdll.dll" -Destination "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN"
-        shell: powershell
 
       - name: Setting up Python
         uses: actions/setup-python@v2
@@ -95,7 +85,7 @@ jobs:
 
       - name: Running unit tests
         run: |
-          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+          if [ "${{ matrix.os }}" == "macos-10.15" ]; then
             export PMD_MPL_BACKEND=TkAgg
           fi
           pytest --showlocals --durations=20 --pyargs pmdarima --benchmark-skip
@@ -103,7 +93,7 @@ jobs:
       - name: Checking for numpy regression
         run: |
           pip install --upgrade numpy
-          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+          if [ "${{ matrix.os }}" == "macos-10.15" ]; then
             export PMD_MPL_BACKEND=TkAgg
           fi
           pytest --showlocals --durations=20 --pyargs pmdarima --benchmark-skip

--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -18,12 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-10.15, ubuntu-latest]
         python-version: ['3.9']
         architecture: ['x86', 'x64']
         exclude:
           # Don't build 32-bit on Mac or Linux
-          - os: macos-latest
+          - os: macos-10.15
             architecture: x86
 
           - os: ubuntu-latest
@@ -109,7 +109,7 @@ jobs:
       - name: Running unit tests
         if: steps.pip-cache.outputs.cache-hit != 'true'
         run: |
-          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+          if [ "${{ matrix.os }}" == "macos-10.15" ]; then
             export PMD_MPL_BACKEND=TkAgg
           fi
           pytest --showlocals --durations=20 --pyargs pmdarima


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

This PR fixes a weird issue we are seeing with our mac builds. `macos-latest` seems to point to [`macos-11`](https://github.com/alkaline-ml/pmdarima/runs/4339908920?check_suite_focus=true#step:1:4) (despite what the [docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) say). However, when it builds a wheel, it builds for [macos-10.14](https://github.com/alkaline-ml/pmdarima/runs/4339908920?check_suite_focus=true#step:11:621) due to our Python version

```
[WARNING] This wheel needs a higher macOS version than the version your Python interpreter is compiled against.  To silence this warning, set MACOSX_DEPLOYMENT_TARGET to at least 11_0 or recreate these files with lower MACOSX_DEPLOYMENT_TARGET:
```

In the short term, we should just specify `macos-10.15`. I think in the long term we may need to cross build and use the environment variable noted above

## Type of change

- [X] Build change

# How Has This Been Tested?

- [X] CI/CD passes

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
