### PR TITLE
[MRG+1] Remove Python 3.6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
   # larger unit tests, and to avoid multiple setup steps that can slow the pipeline down
   test-sanity:
     docker:
-      - image: python:3.6
+      - image: python:3.7
     working_directory: ~/pmdarima
     steps:
     - checkout
@@ -132,15 +132,6 @@ jobs:
   # --- Unit tests ---
   # These are all executed on `machine` executors, since they require DinD to build the whl
   # files and perform the whl repair for manylinux support.
-  test-unit-cpython36:
-    machine:
-      image: circleci/classic:latest
-    working_directory: ~/pmdarima
-    steps:
-      - checkout
-      - build-test-and-persist:
-          pythonversion: "3.6"
-
   test-unit-cpython37:
     machine:
       image: circleci/classic:latest
@@ -210,16 +201,6 @@ jobs:
   #
   # ############################################
 
-  deploy-cpython36-whl:
-    machine:
-      image: circleci/classic:latest
-    working_directory: ~/pmdarima
-    steps:
-      - checkout
-      - restore-whl-file:
-          key: "3.6"
-      - deploy-to-pypi
-
   deploy-cpython37-whl:
     machine:
       image: circleci/classic:latest
@@ -268,7 +249,7 @@ jobs:
   # GH_TOKEN (the personal Git token with pushes enabled)
   deploy-doc:
     docker:
-      - image: python:3.6
+      - image: python:3.7
     working_directory: ~/pmdarima
     steps:
       - checkout
@@ -287,8 +268,6 @@ workflows:
         # run on test and tag
         - test-sanity:
             filters: *test-filters
-        - test-unit-cpython36:
-            filters: *test-filters
         - test-unit-cpython37:
             filters: *test-filters
         - test-unit-cpython38:
@@ -302,7 +281,6 @@ workflows:
         - testing-passed:
             requires:
                 - test-sanity
-                - test-unit-cpython36
                 - test-unit-cpython37
                 - test-unit-cpython38
                 - test-unit-cpython39
@@ -316,11 +294,6 @@ workflows:
                 - build-doc
                 - testing-passed
             filters: *test-filters
-
-        - deploy-cpython36-whl:
-            filters: *deploy-filters
-            requires:
-                - deploy-doc
 
         - deploy-cpython37-whl:
             filters: *deploy-filters

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-10.15]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         architecture: ['x86', 'x64']
         exclude:
           # Don't build 32-bit on Mac

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CircleCI](https://circleci.com/gh/alkaline-ml/pmdarima.svg?style=svg)](https://circleci.com/gh/alkaline-ml/pmdarima)
 [![Github Actions Status](https://github.com/alkaline-ml/pmdarima/workflows/Mac%20and%20Windows%20Builds/badge.svg?branch=master)](https://github.com/alkaline-ml/pmdarima/actions?query=workflow%3A%22Mac+and+Windows+Builds%22+branch%3Amaster)
 [![codecov](https://codecov.io/gh/alkaline-ml/pmdarima/branch/master/graph/badge.svg)](https://codecov.io/gh/alkaline-ml/pmdarima)
-![Supported versions](https://img.shields.io/badge/python-3.6+-blue.svg)
+![Supported versions](https://img.shields.io/badge/python-3.7+-blue.svg)
 ![Downloads](https://img.shields.io/badge/dynamic/json?color=blue&label=downloads&query=%24.total&url=https%3A%2F%2Fstore.zapier.com%2Fapi%2Frecords%3Fsecret%3D1e061b29db6c4f15af01103d403b0237)
 ![Downloads/Week](https://img.shields.io/badge/dynamic/json?color=blue&label=downloads%2Fweek&query=%24.weekly&url=https%3A%2F%2Fstore.zapier.com%2Fapi%2Frecords%3Fsecret%3D1e061b29db6c4f15af01103d403b0237)
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,6 +12,8 @@ v0.8.1) will document the latest features.
 
 * Add support for Python 3.10
 
+* Remove support for Python 3.6
+
 
 `v1.8.4 <http://alkaline-ml.com/pmdarima/1.8.4/>`_
 --------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import importlib
 import builtins
 
 # Minimum allowed version
-MIN_PYTHON = (3, 6)
+MIN_PYTHON = (3, 7)
 
 # Hacky (!!), adopted from sklearn. This sets a global variable
 # so pmdarima __init__ can detect if it's being loaded in the setup
@@ -238,7 +238,6 @@ def do_setup():
                         'Operating System :: Unix',
                         'Operating System :: MacOS',
                         'Programming Language :: Python :: 3',
-                        'Programming Language :: Python :: 3.6',
                         'Programming Language :: Python :: 3.7',
                         'Programming Language :: Python :: 3.8',
                         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Python 3.6 was [end-of-lifed on 2021-12-23](https://endoflife.date/python). This PR removes supports for Python 3.6.

Will need to change the "required checks" for this to pass. This will also conflict with #459, so I will have to update one depending one which is merged first 

## Type of change

- [X] CI/Deployment change

# How Has This Been Tested?

N/A

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
