### PR TITLE
[MRG] Don't use deprecated circlci/classic machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
   # files and perform the whl repair for manylinux support.
   test-unit-cpython37:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     working_directory: ~/pmdarima
     steps:
       - checkout
@@ -143,7 +143,7 @@ jobs:
 
   test-unit-cpython38:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     working_directory: ~/pmdarima
     steps:
       - checkout
@@ -152,7 +152,7 @@ jobs:
 
   test-unit-cpython39:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     working_directory: ~/pmdarima
     steps:
       - checkout
@@ -161,7 +161,7 @@ jobs:
 
   test-unit-cpython310:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     working_directory: ~/pmdarima
     steps:
       - checkout
@@ -203,7 +203,7 @@ jobs:
 
   deploy-cpython37-whl:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     working_directory: ~/pmdarima
     steps:
       - checkout
@@ -213,7 +213,7 @@ jobs:
 
   deploy-cpython38-whl:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     working_directory: ~/pmdarima
     steps:
       - checkout
@@ -223,7 +223,7 @@ jobs:
 
   deploy-cpython39-whl:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     working_directory: ~/pmdarima
     steps:
       - checkout
@@ -233,7 +233,7 @@ jobs:
 
   deploy-cpython310-whl:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     working_directory: ~/pmdarima
     steps:
       - checkout


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

`circleci/classic` machines are being deprecated and removed ([blog post](https://circleci.com/blog/ubuntu-14-16-image-deprecation/)). This PR updates our Circle jobs that run on those VMs to run on `ubuntu-2004:202111-02` instead

## Type of change

- [X] Maintenance change
- [X] CI/CD Change

# How Has This Been Tested?

I am hoping CI passes 🤞🏻 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
