### PR TITLE
[MRG+2] fix comments and doc which refer to n_fits as n_iter

### DIFF
--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -95,7 +95,7 @@ class _RandomFitWrapper(_SolverMixin):
             )
 
         # if we are fitting a random search rather than an exhaustive one, we
-        # will scramble up the generator (as a list) and only fit n_iter ARIMAs
+        # will scramble up the generator (as a list) and only fit n_fits ARIMAs
         if random:
             random_state = check_random_state(random_state)
 

--- a/pmdarima/arima/_doc.py
+++ b/pmdarima/arima/_doc.py
@@ -214,7 +214,7 @@ _AUTO_ARIMA_DOCSTR = \
 
     n_fits : int, optional (default=10)
         If ``random`` is True and a "random search" is going to be performed,
-        ``n_iter`` is the number of ARIMA models to be fit.
+        ``n_fits`` is the number of ARIMA models to be fit.
     {return_valid_fits}
     out_of_sample_size : int, optional (default=0)
         The ``ARIMA`` class can fit only a portion of the data if specified,

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -420,9 +420,9 @@ def auto_arima(y,
                 raise ValueError('d & D must be None or a positive '
                                  'integer (>= 0)')
 
-    # check on n_iter
+    # check on n_fits
     if random and n_fits < 0:
-        raise ValueError('n_iter must be a positive integer '
+        raise ValueError('n_fits must be a positive integer '
                          'for a random search')
 
     # validate error action

--- a/pmdarima/arima/tests/test_auto.py
+++ b/pmdarima/arima/tests/test_auto.py
@@ -83,7 +83,7 @@ def test_corner_cases():
                              return_valid_fits=True)
         assert hasattr(fits, '__iter__')
 
-    # show we fail for n_iter < 0
+    # show we fail for n_fits < 0
     with pytest.raises(ValueError):
         pm.auto_arima(np.ones(10), random=True, n_fits=-1)
 


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Please include a summary of the change and which issue is fixed:

When reading the docs I noticed that n_fits (which is used to determine the number of test iterations used to fit in random search cases) is sometimes referred to as n_iter. It looks like n_fits is the variable name that's actually in use. I looked for usages of n_iter and changed the ones which referred to n_fits. This is a very minor change which affects a few comments, one reference in documentation, and the text of a single error that's thrown if n_fits is negative. Please feel free to edit or reject.

Fixes # n/a
This is such a minor change (at first I thought it was doc-only) that I didn't file an issue first. Please let me know if I need to!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Please also list any relevant details
for your test configuration

I haven't run tests locally because this doesn't really change any functionality - I expect the CI to succeed, if it doesn't I can debug locally. 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [n/a] New and existing unit tests pass locally with my changes
