### PR TITLE
[MRG+1] Add 'concurrency' block to GHA and fix build warnings

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - '*'
 
+# Cancel older runs of the same workflow on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy:
     name: Build and Deploy

--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: '0 7 * * *'  # Every day at 07:00 UTC (1AM CST or 2AM CDT)
 
+# Cancel older runs of the same workflow on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build against latest dependencies

--- a/.github/workflows/test_tagging.yml
+++ b/.github/workflows/test_tagging.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - '*'
 
+# Cancel older runs of the same workflow on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-tagging:
     name: Test VERSION tagging

--- a/pmdarima/arima/seasonality.py
+++ b/pmdarima/arima/seasonality.py
@@ -8,6 +8,8 @@ from collections import namedtuple
 
 import math
 from sklearn.linear_model import LinearRegression
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
 
 from scipy.linalg import svd
 from statsmodels import api as sm
@@ -226,12 +228,15 @@ class CHTest(_SeasonalStationarityTest):
 
         # no use checking, because this is an internal method
         # if n <= s:  raise ValueError('too few samples (%i<=%i)' % (n, s))
-        frec = np.ones(int((s + 1) / 2), dtype=np.int)
+        frec = np.ones(int((s + 1) / 2), dtype=int)
         ltrunc = int(np.round(s * ((n / 100.0) ** 0.25)))
         R1 = CHTest._seas_dummy(wts, s)
 
         # fit model, get residuals
-        lmch = LinearRegression(normalize=True).fit(R1, wts)
+        lmch = make_pipeline(
+            StandardScaler(with_mean=False),
+            LinearRegression()
+        ).fit(R1, wts)
         # lmch = sm.OLS(wts, R1).fit(method='qr')
         residuals = wts - lmch.predict(R1)
 

--- a/pmdarima/model_selection/_split.py
+++ b/pmdarima/model_selection/_split.py
@@ -118,8 +118,8 @@ class BaseTSCrossValidator(BaseEstimator, metaclass=abc.ABCMeta):
     def _iter_train_test_masks(self, y, X):
         """Generate boolean masks corresponding to test sets"""
         for train_index, test_index in self._iter_train_test_indices(y, X):
-            train_mask = np.zeros(y.shape[0], dtype=np.bool)
-            test_mask = np.zeros(y.shape[0], dtype=np.bool)
+            train_mask = np.zeros(y.shape[0], dtype=bool)
+            test_mask = np.zeros(y.shape[0], dtype=bool)
 
             train_mask[train_index] = True
             test_mask[test_index] = True

--- a/pmdarima/utils/tests/test_array.py
+++ b/pmdarima/utils/tests/test_array.py
@@ -135,7 +135,7 @@ def test_diff():
 )
 def test_diff_inv(arr, lag, differences, xi, expected):
     res = diff_inv(arr, lag=lag, differences=differences, xi=xi)
-    expected = np.array(expected, dtype=np.float)
+    expected = np.array(expected, dtype=float)
     assert_array_equal(expected, res)
 
 


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

This PR makes it so if we push a commit to the same branch, it will cancel previous builds on GHA, saving us some cycles.

It also fixes a couple warnings in the build:

- `np.int` -> `int`
- `np.bool` -> `bool`
- `np.float` -> `float`
- `LinearRegression(normalize=True)` was apparently deprecated by sklearn in favor of `make_pipeline(StandardScaler(with_mean=False), LinearRegression())`

    ```
    /Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sklearn/linear_model/_base.py:145: FutureWarning: 'normalize' was deprecated in version 1.0 and will be removed in 1.2.
  If you wish to scale the data, use Pipeline with a StandardScaler in a preprocessing stage. To reproduce the previous behavior:
  
  from sklearn.pipeline import make_pipeline
  
  model = make_pipeline(StandardScaler(with_mean=False), LinearRegression())
  
  If you wish to pass a sample_weight parameter, you need to pass it as a fit parameter to each step of the pipeline as follows:
  
  kwargs = {s[0] + '__sample_weight': sample_weight for s in model.steps}
  model.fit(X, y, **kwargs)
    ``` 

## Type of change

- [X] CI/CD change
- [X] Fix deprecations

# How Has This Been Tested?

- [X] Tests still pass
- [X] Most warnings are gone
- [X] Old builds cancel on push to same branch

# Checklist:

N/A
