### PR TITLE
[MRG+1] Sunset 32-bit builds

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -23,16 +23,6 @@ jobs:
       matrix:
         os: [windows-latest, macos-10.15]
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        architecture: ['x86', 'x64']
-        exclude:
-          # Don't build 32-bit on Mac
-          - os: macos-10.15
-            architecture: x86
-
-          # Numpy does not build for 32-bit windows starting with Python 3.10, so we also have to exclude it
-          - os: windows-latest
-            architecture: x86
-            python-version: 3.10
     defaults:
       run:
         shell: bash
@@ -49,7 +39,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
 
       # https://github.com/actions/cache/blob/master/examples.md#multiple-oss-in-a-workflow
       - name: Checking for cached pip dependencies (macOS)

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ with open('model.pkl', 'rb') as pkl:
 * Mac (64-bit)
 * Linux (64-bit manylinux)
 * Windows (64-bit)
-  * 32-bit wheels are available for pmdarima versions below 2.0.0 and Python version below 3.10
+  * 32-bit wheels are available for pmdarima versions below 2.0.0 and Python versions below 3.10
 
 If a wheel doesn't exist for your platform, you can still `pip install` and it
 will build from the source distribution tarball, however you'll need `cython>=0.29`

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ with open('model.pkl', 'rb') as pkl:
 
 * Mac (64-bit)
 * Linux (64-bit manylinux)
-* Windows (32 & 64-bit)
-  * 32-bit is only supported for Python versions below 3.10
+* Windows (64-bit)
+  * 32-bit wheels are available for pmdarima versions below 2.0.0 and Python version below 3.10
 
 If a wheel doesn't exist for your platform, you can still `pip install` and it
 will build from the source distribution tarball, however you'll need `cython>=0.29`

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,6 +20,8 @@ v0.8.1) will document the latest features.
 
   - A falsey value for ARIMA's ``maxiter`` argument will now raise a ``ValueError`` (warning since 1.5.0)
 
+  - ``pmdarima`` is no longer built for 32-bit architectures
+
 * Bump numpy dependency to >= 1.21
 
 * Expose ``fittedvalues`` in the public API. See `#493 <https://github.com/alkaline-ml/pmdarima/issues/493>`_


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Windows is 1-2% of our user base ([source](https://pypistats.org/packages/pmdarima)) with 32-bit probably being a small fraction of that. Microsoft stopped offering 32-bit Windows in 2020, so there is no need to continue supporting it. We already stopped building 32-bit for 3.10+ due to dependencies not supporting it, v2.0 seems as good a time as ever to remove it completely. This should also help our build times since it reclaims 3 builds on each commit in GHA.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] CI/CD change

# How Has This Been Tested?

N/A

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
