### PR TITLE
[MRG+1] Allow `predict_in_sample` for non-integer start/end indices

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -28,6 +28,9 @@ v0.8.1) will document the latest features.
 
 * Add support for ARM64 architecture. See `#434 <https://github.com/alkaline-ml/pmdarima/issues/434>`_
 
+* Introduce new arg, ``preserve_series``, to ``pmdarima.utils.check_endog`` that will preserve or squeeze
+  a Pandas ``Series`` object to preserve index information.
+
 `v1.8.5 <http://alkaline-ml.com/pmdarima/1.8.5>`_
 -------------------------------------------------
 

--- a/pmdarima/arima/approx.py
+++ b/pmdarima/arima/approx.py
@@ -53,7 +53,7 @@ def _regularize(x, y, ties):
         One of {'ordered', 'mean'}, handles the ties.
     """
     x, y = [
-        check_endog(arr, dtype=DTYPE)
+        check_endog(arr, dtype=DTYPE, preserve_series=False)
         for arr in (x, y)
     ]
 

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -419,7 +419,7 @@ def auto_arima(
     start = time.time()
 
     # copy array
-    y = check_endog(y, dtype=DTYPE)
+    y = check_endog(y, dtype=DTYPE, preserve_series=True)
     n_samples = y.shape[0]
 
     # the workhorse of the model fits

--- a/pmdarima/arima/seasonality.py
+++ b/pmdarima/arima/seasonality.py
@@ -356,7 +356,7 @@ class CHTest(_SeasonalStationarityTest):
             return 0
 
         # ensure vector
-        x = check_endog(x, dtype=DTYPE)
+        x = check_endog(x, dtype=DTYPE, preserve_series=False)
 
         n = x.shape[0]
         m = int(self.m)
@@ -591,7 +591,7 @@ class OCSBTest(_SeasonalStationarityTest):
             return 0
 
         # ensure vector
-        x = check_endog(x, dtype=DTYPE)
+        x = check_endog(x, dtype=DTYPE, preserve_series=False)
 
         # Get the critical value for m
         stat = self._compute_test_statistic(x)

--- a/pmdarima/arima/stationarity.py
+++ b/pmdarima/arima/stationarity.py
@@ -162,7 +162,7 @@ class KPSSTest(_DifferencingStationarityTest):
             return np.nan, False
 
         # ensure vector
-        x = check_endog(x, dtype=DTYPE)
+        x = check_endog(x, dtype=DTYPE, preserve_series=False)
         n = x.shape[0]
 
         # check on status of null
@@ -321,7 +321,7 @@ class ADFTest(_DifferencingStationarityTest):
             return np.nan, False
 
         # ensure vector
-        x = check_endog(x, dtype=DTYPE)
+        x = check_endog(x, dtype=DTYPE, preserve_series=False)
 
         # if k is none...
         k = self.k
@@ -436,7 +436,7 @@ class PPTest(_DifferencingStationarityTest):
             return np.nan, False
 
         # ensure vector
-        x = check_endog(x, dtype=DTYPE)
+        x = check_endog(x, dtype=DTYPE, preserve_series=False)
 
         # embed the vector. This is some funkiness that goes on in the R
         # code... basically, make a matrix where the column (rows if not T)

--- a/pmdarima/metrics.py
+++ b/pmdarima/metrics.py
@@ -45,7 +45,15 @@ def smape(y_true, y_pred):
     ----------
     .. [1] https://en.wikipedia.org/wiki/Symmetric_mean_absolute_percentage_error
     """    # noqa: E501
-    y_true = check_endog(y_true)  # type: np.ndarray
-    y_pred = check_endog(y_pred)  # type: np.ndarray
+    y_true = check_endog(
+        y_true,
+        copy=False,
+        preserve_series=False,
+    )
+    y_pred = check_endog(
+        y_pred,
+        copy=False,
+        preserve_series=False,
+    )
     abs_diff = np.abs(y_pred - y_true)
     return np.mean((abs_diff * 200 / (np.abs(y_pred) + np.abs(y_true))))

--- a/pmdarima/model_selection/_validation.py
+++ b/pmdarima/model_selection/_validation.py
@@ -183,7 +183,7 @@ def cross_validate(
         does not affect the refit step, which will always raise the error.
     """
     y, X = indexable(y, X)
-    y = check_endog(y, copy=False)
+    y = check_endog(y, copy=False, preserve_series=True)
 
     cv = check_cv(cv)
     scoring = _check_scoring(scoring)
@@ -299,7 +299,7 @@ def cross_val_predict(
            25473.60876435])
     """
     y, X = indexable(y, X)
-    y = check_endog(y, copy=False)
+    y = check_endog(y, copy=False, preserve_series=True)
     cv = check_cv(cv)
     avgfunc = _check_averaging(averaging)
 

--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -197,7 +197,7 @@ class Pipeline(BaseEstimator):
         # Shallow copy
         steps = self.steps_ = self._validate_steps()
 
-        yt = check_endog(y, dtype=DTYPE, copy=False)
+        yt = check_endog(y, dtype=DTYPE, copy=False, preserve_series=True)
         Xt = X
         named_kwargs = self._get_kwargs(**fit_kwargs)
 

--- a/pmdarima/preprocessing/base.py
+++ b/pmdarima/preprocessing/base.py
@@ -33,10 +33,21 @@ class BaseTransformer(BaseEstimator, TransformerMixin, metaclass=abc.ABCMeta):
         """Validate input"""
         # Do not force finite, since a transformer's goal may be imputation.
         if y is not None:
-            y = check_endog(y, dtype=DTYPE, copy=True, force_all_finite=False)
+            y = check_endog(
+                y,
+                dtype=DTYPE,
+                copy=True,
+                force_all_finite=False,
+                preserve_series=False,
+            )
 
         if X is not None:
-            X = check_exog(X, dtype=None, copy=True, force_all_finite=False)
+            X = check_exog(
+                X,
+                dtype=None,
+                copy=True,
+                force_all_finite=False,
+            )
         return y, X
 
     def fit_transform(self, y, X=None, **kwargs):

--- a/pmdarima/utils/visualization.py
+++ b/pmdarima/utils/visualization.py
@@ -373,7 +373,7 @@ def tsdisplay(y, lag_max=50, figsize=(8, 6), title=None, bins=25,
     ax2 = fig.add_subplot(gs[2:, 1])
 
     # make sure y is a np array
-    y = check_endog(y, copy=False)
+    y = check_endog(y, copy=False, preserve_series=True)
 
     if lag_max >= y.shape[0]:
         raise ValueError(


### PR DESCRIPTION
# Description

Permit users to produce in-sample predictions over indices that are non-integer, e.g. `model.predict_in_sample(start="20220103", end="20220106")`

Fixes #499 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation change

# How Has This Been Tested?

- Add new tests for `check_endog` to assert we can preserve the index information
- Add two new ARIMA tests that show fitting over an index with a datetime dtype will allow users to predict either with an integer or date `start` value

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
