### PR TITLE
[MRG] Normalize on manylinux_2_28

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -144,7 +144,7 @@ jobs:
         python-version: [cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310]
     env:
       python: /opt/python/${{ matrix.python-version }}/bin/python
-      image: quay.io/pypa/manylinux2014_aarch64
+      image: quay.io/pypa/manylinux_2_28_aarch64
     defaults:
       run:
         shell: bash

--- a/build_tools/circle/build_wheel.sh
+++ b/build_tools/circle/build_wheel.sh
@@ -23,7 +23,7 @@ function build_wheel {
 
     DOCKER_CONTAINER_NAME=wheel_builder_$(uuidgen)
 
-    ML_IMAGE="quay.io/pypa/manylinux_2_24_${arch}:2021-08-29-ad54d32" # `latest` as of 2021-08-30
+    ML_IMAGE="quay.io/pypa/manylinux_2_28_${arch}:2022-06-08-6ab6a6f" # `latest` as of 2022-06-8
     PMDARIMA_VERSION=`cat ~/pmdarima/pmdarima/VERSION`
 
     docker pull "${ML_IMAGE}"


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Manylinux 2_24 is being EOLd, so we should use 2014 or 2_28. This PR standardizes on 2_28. See [this thread](https://github.com/pypa/manylinux/issues/1332#issuecomment-1148030224) for detail.

## Type of change

- [X] Build change

# How Has This Been Tested?

2_24 images can use a 2_28 wheel:

```
$ docker run -it -v $(pwd)/dist:/io quay.io/pypa/manylinux_2_24_x86_64 /bin/bash
root@ac32d12348a7:/# PYTHON=/opt/python/cp37-cp37m/bin/python
root@ac32d12348a7:/# PIP=/opt/python/cp37-cp37m/bin/pip
root@ac32d12348a7:/# $PIP install /io/pmdarima-0.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl 
Processing /io/pmdarima-0.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl
Collecting scipy>=1.3.2
  Downloading scipy-1.7.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (38.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 38.1/38.1 MB 5.7 MB/s eta 0:00:00
Collecting joblib>=0.11
  Downloading joblib-1.1.0-py2.py3-none-any.whl (306 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 307.0/307.0 kB 5.4 MB/s eta 0:00:00
Collecting urllib3
  Downloading urllib3-1.26.9-py2.py3-none-any.whl (138 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 139.0/139.0 kB 9.0 MB/s eta 0:00:00
Collecting Cython!=0.29.18,>=0.29
  Downloading Cython-0.29.30-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl (1.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.9/1.9 MB 5.6 MB/s eta 0:00:00
Collecting numpy>=1.21
  Downloading numpy-1.21.6-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (15.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 15.7/15.7 MB 3.9 MB/s eta 0:00:00
Collecting statsmodels>=0.13.2
  Downloading statsmodels-0.13.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (9.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 9.8/9.8 MB 4.7 MB/s eta 0:00:00
Requirement already satisfied: setuptools!=50.0.0,>=38.6.0 in /opt/_internal/cpython-3.7.13/lib/python3.7/site-packages (from pmdarima==0.0.0) (62.3.2)
Collecting scikit-learn>=0.22
  Downloading scikit_learn-1.0.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (24.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 24.8/24.8 MB 3.9 MB/s eta 0:00:00
Collecting pandas>=0.19
  Downloading pandas-1.3.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 11.3/11.3 MB 3.7 MB/s eta 0:00:00
Collecting pytz>=2017.3
  Downloading pytz-2022.1-py2.py3-none-any.whl (503 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 503.5/503.5 kB 3.6 MB/s eta 0:00:00
Collecting python-dateutil>=2.7.3
  Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 kB 4.7 MB/s eta 0:00:00
Collecting threadpoolctl>=2.0.0
  Downloading threadpoolctl-3.1.0-py3-none-any.whl (14 kB)
Collecting patsy>=0.5.2
  Downloading patsy-0.5.2-py2.py3-none-any.whl (233 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 233.7/233.7 kB 3.6 MB/s eta 0:00:00
Requirement already satisfied: packaging>=21.3 in /opt/_internal/cpython-3.7.13/lib/python3.7/site-packages (from statsmodels>=0.13.2->pmdarima==0.0.0) (21.3)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /opt/_internal/cpython-3.7.13/lib/python3.7/site-packages (from packaging>=21.3->statsmodels>=0.13.2->pmdarima==0.0.0) (3.0.9)
Collecting six
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: pytz, urllib3, threadpoolctl, six, numpy, joblib, Cython, scipy, python-dateutil, patsy, scikit-learn, pandas, statsmodels, pmdarima
Successfully installed Cython-0.29.30 joblib-1.1.0 numpy-1.21.6 pandas-1.3.5 patsy-0.5.2 pmdarima-0.0.0 python-dateutil-2.8.2 pytz-2022.1 scikit-learn-1.0.2 scipy-1.7.3 six-1.16.0 statsmodels-0.13.2 threadpoolctl-3.1.0 urllib3-1.26.9
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
root@ac32d12348a7:/# $PYTHON
Python 3.7.13 (default, Jun  8 2022, 06:54:01) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pmdarima as pm
>>> pm.show_versions()
/opt/python/cp37-cp37m/lib/python3.7/site-packages/_distutils_hack/__init__.py:30: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")

System:
    python: 3.7.13 (default, Jun  8 2022, 06:54:01)  [GCC 6.3.0 20170516]
executable: /opt/python/cp37-cp37m/bin/python
   machine: Linux-5.10.47-linuxkit-x86_64-with-debian-9.13

Python dependencies:
        pip: 22.1.2
 setuptools: 62.3.2
    sklearn: 1.0.2
statsmodels: 0.13.2
      numpy: 1.21.6
      scipy: 1.7.3
     Cython: 0.29.30
     pandas: 1.3.5
     joblib: 1.1.0
   pmdarima: 0.0.0
```

2_28 images can use a 2_24 wheel:

```
$ docker run -it -v $(pwd)/dist:/io quay.io/pypa/manylinux_2_28_x86_64:2022-06-08-6ab6a6f /bin/bash
[root@0a504f78fa7c /]# PYTHON=/opt/python/cp37-cp37m/bin/python
[root@0a504f78fa7c /]# PIP=/opt/python/cp37-cp37m/bin/pip
[root@0a504f78fa7c /]# $PIP install /io/pmdarima-0.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl 
Processing /io/pmdarima-0.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl
Collecting numpy>=1.21
  Downloading numpy-1.21.6-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (15.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 15.7/15.7 MB 7.0 MB/s eta 0:00:00
Collecting scikit-learn>=0.22
  Downloading scikit_learn-1.0.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (24.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 24.8/24.8 MB 7.6 MB/s eta 0:00:00
Collecting joblib>=0.11
  Downloading joblib-1.1.0-py2.py3-none-any.whl (306 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 307.0/307.0 kB 9.8 MB/s eta 0:00:00
Collecting pandas>=0.19
  Downloading pandas-1.3.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 11.3/11.3 MB 5.4 MB/s eta 0:00:00
Collecting Cython!=0.29.18,>=0.29
  Downloading Cython-0.29.30-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl (1.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.9/1.9 MB 6.2 MB/s eta 0:00:00
Collecting statsmodels>=0.13.2
  Downloading statsmodels-0.13.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (9.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 9.8/9.8 MB 7.0 MB/s eta 0:00:00
Collecting urllib3
  Downloading urllib3-1.26.9-py2.py3-none-any.whl (138 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 139.0/139.0 kB 9.7 MB/s eta 0:00:00
Collecting scipy>=1.3.2
  Downloading scipy-1.7.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (38.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 38.1/38.1 MB 4.8 MB/s eta 0:00:00
Requirement already satisfied: setuptools!=50.0.0,>=38.6.0 in /opt/_internal/cpython-3.7.13/lib/python3.7/site-packages (from pmdarima==0.0.0) (62.3.2)
Collecting python-dateutil>=2.7.3
  Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 kB 6.6 MB/s eta 0:00:00
Collecting pytz>=2017.3
  Downloading pytz-2022.1-py2.py3-none-any.whl (503 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 503.5/503.5 kB 4.6 MB/s eta 0:00:00
Collecting threadpoolctl>=2.0.0
  Downloading threadpoolctl-3.1.0-py3-none-any.whl (14 kB)
Collecting patsy>=0.5.2
  Downloading patsy-0.5.2-py2.py3-none-any.whl (233 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 233.7/233.7 kB 7.3 MB/s eta 0:00:00
Requirement already satisfied: packaging>=21.3 in /opt/_internal/cpython-3.7.13/lib/python3.7/site-packages (from statsmodels>=0.13.2->pmdarima==0.0.0) (21.3)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /opt/_internal/cpython-3.7.13/lib/python3.7/site-packages (from packaging>=21.3->statsmodels>=0.13.2->pmdarima==0.0.0) (3.0.9)
Collecting six
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: pytz, urllib3, threadpoolctl, six, numpy, joblib, Cython, scipy, python-dateutil, patsy, scikit-learn, pandas, statsmodels, pmdarima
Successfully installed Cython-0.29.30 joblib-1.1.0 numpy-1.21.6 pandas-1.3.5 patsy-0.5.2 pmdarima-0.0.0 python-dateutil-2.8.2 pytz-2022.1 scikit-learn-1.0.2 scipy-1.7.3 six-1.16.0 statsmodels-0.13.2 threadpoolctl-3.1.0 urllib3-1.26.9
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
[root@0a504f78fa7c /]# $PYTHON
Python 3.7.13 (default, Jun  8 2022, 06:50:53) 
[GCC 11.2.1 20220127 (Red Hat 11.2.1-9)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pmdarima as pm
>>> pm.show_versions()
/opt/python/cp37-cp37m/lib/python3.7/site-packages/_distutils_hack/__init__.py:30: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")

System:
    python: 3.7.13 (default, Jun  8 2022, 06:50:53)  [GCC 11.2.1 20220127 (Red Hat 11.2.1-9)]
executable: /opt/python/cp37-cp37m/bin/python
   machine: Linux-5.10.47-linuxkit-x86_64-with-centos-8.6-Sky_Tiger

Python dependencies:
        pip: 22.1.2
 setuptools: 62.3.2
    sklearn: 1.0.2
statsmodels: 0.13.2
      numpy: 1.21.6
      scipy: 1.7.3
     Cython: 0.29.30
     pandas: 1.3.5
     joblib: 1.1.0
   pmdarima: 0.0.0
```

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
