### PR TITLE
[MRG] Update macOS version we build on and update Cython pin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
 
           # we'll need numpy and cython to build this. let install_requires do all the
           # rest of the work. We build with our lowest supported numpy version to make sure there is no regression
-          pip install "numpy~=1.19.3" "cython>=0.29,!=0.29.18"
+          pip install "numpy~=1.19.3" "cython>=0.29,!=0.29.18,!=0.29.31"
           python setup.py sdist
 
           cd dist

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build and Deploy
     strategy:
       matrix:
-        os: [windows-latest, macos-10.15]
+        os: [windows-latest, macos-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
     defaults:
       run:
@@ -76,7 +76,7 @@ jobs:
 
       - name: Running unit tests
         run: |
-          if [ "${{ matrix.os }}" == "macos-10.15" ]; then
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
             export PMD_MPL_BACKEND=TkAgg
           fi
           pytest --showlocals --durations=20 --pyargs pmdarima
@@ -84,7 +84,7 @@ jobs:
       - name: Checking for numpy regression
         run: |
           pip install --upgrade numpy
-          if [ "${{ matrix.os }}" == "macos-10.15" ]; then
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
             export PMD_MPL_BACKEND=TkAgg
           fi
           pytest --showlocals --durations=20 --pyargs pmdarima

--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -23,12 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-10.15, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ['3.9']
         architecture: ['x86', 'x64']
         exclude:
           # Don't build 32-bit on Mac or Linux
-          - os: macos-10.15
+          - os: macos-latest
             architecture: x86
 
           - os: ubuntu-latest
@@ -114,7 +114,7 @@ jobs:
       - name: Running unit tests
         if: steps.pip-cache.outputs.cache-hit != 'true'
         run: |
-          if [ "${{ matrix.os }}" == "macos-10.15" ]; then
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
             export PMD_MPL_BACKEND=TkAgg
           fi
           pytest --showlocals --durations=20 --pyargs pmdarima

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -1,6 +1,6 @@
 numpy~=1.21.2
 scipy>=1.3.2
-cython>=0.29,!=0.29.18
+cython>=0.29,!=0.29.18,!=0.29.31
 scikit-learn>=0.22
 pandas>=0.19
 statsmodels>=0.11,!=0.12.0

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,8 @@ v0.8.1) will document the latest features.
 
   - ``pmdarima`` is no longer built for 32-bit architectures
 
+  - macOS images are built using macOS 11 instead of macOS 10.15
+
 * Bump numpy dependency to >= 1.21
 
 * Expose ``fittedvalues`` in the public API. See `#493 <https://github.com/alkaline-ml/pmdarima/issues/493>`_
@@ -30,6 +32,8 @@ v0.8.1) will document the latest features.
 
 * Introduce new arg, ``preserve_series``, to ``pmdarima.utils.check_endog`` that will preserve or squeeze
   a Pandas ``Series`` object to preserve index information.
+
+* Update Cython pinned version to include ``!=0.29.31``
 
 `v1.8.5 <http://alkaline-ml.com/pmdarima/1.8.5>`_
 -------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 joblib>=0.11
-Cython>=0.29,!=0.29.18
+Cython>=0.29,!=0.29.18,!=0.29.31
 numpy>=1.21
 pandas>=0.19
 scikit-learn>=0.22


### PR DESCRIPTION
# Description

Cython version `0.29.31` broke our nightly build, so we want to avoid that (we have confirmed that the new `0.29.32` works). Separately macOS `10.15` is [deprecated by GitHub](https://github.com/actions/virtual-environments/issues/5583) so we bump to `macos-latest` (which is currently macOS `11`).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI/CD passes

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
