### PR TITLE
[MRG+1] - Added extra info to ValueError in predict()

### DIFF
--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -312,13 +312,13 @@ class ARIMA(BaseARIMA):
     scoring : str or callable, optional (default='mse')
         If performing validation (i.e., if ``out_of_sample_size`` > 0), the
         metric to use for scoring the out-of-sample data:
-        
+
             * If a string, must be a valid metric name importable from
               ``sklearn.metrics``.
             * If a callable, must adhere to the function signature::
-            
+
                 def foo_loss(y_true, y_pred)
-                
+
         Note that models are selected by *minimizing* loss. If using a
         maximizing metric (such as ``sklearn.metrics.r2_score``), it is the
         user's responsibility to wrap the function such that it returns a
@@ -388,7 +388,7 @@ class ARIMA(BaseARIMA):
     ----------
     arima_res_ : ModelResultsWrapper
         The model results, per statsmodels
-        
+
     endog_index_ : pd.Series or None
         If the fitted endog array is a ``pd.Series``, this value will be
         non-None and is used to validate args for in-sample predictions with
@@ -784,7 +784,10 @@ class ARIMA(BaseARIMA):
         # if we fit with exog, make sure one was passed:
         X = self._check_exog(X)  # type: np.ndarray
         if X is not None and X.shape[0] != n_periods:
-            raise ValueError('X array dims (n_rows) != n_periods')
+            raise ValueError(
+                f'X array dims (n_rows) != n_periods. Received '
+                f'n_rows={X.shape[0]} and n_periods={n_periods}'
+            )
 
         # f = self.arima_res_.forecast(steps=n_periods, exog=X)
         arima = self.arima_res_


### PR DESCRIPTION
# Description

Changes:
- Printed `n_rows` and `n_periods` to screen in `ValueError` message. 
- Added spaces to other docstrings that were close together (automatically added by black formatter)

Motivation:
- I was using this method through the `sktime` package and kept getting this error. I was frustrated that neither `n_rows` or `n_periods` were printed to the screen as I was quite sure I was doing everything correctly. 

## Type of change

- [✅] Documentation change

# How Has This Been Tested?

No tests since it's just a doc change. Plus I had issues running pytest locally despite following your instructions.

# Checklist:

- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [❌] New and existing unit tests pass locally with my changes

I've spent the last hour trying to get pytest to run locally but without success. 

What I have tried:
- Creating a new conda env and running `python setup.py develop`, running `make` running `python setup.py install`
- Installing `gcc` with homebrew

The installs all seemingly work but when I run pytest I get the following errors. What am I doing wrong?!

```python
ImportError while importing test module '/Volumes/GoogleDrive/My Drive/1 Projects/pmdarima - update ARIMA.predict ValueError/pmdarima/pmdarima/utils/tests/test_wrapped.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
pmdarima/__check_build/__init__.py:44: in <module>
    from ._check_build import check_build
E   ModuleNotFoundError: No module named 'pmdarima.__check_build._check_build'

During handling of the above exception, another exception occurred:
/Users/king/opt/anaconda3/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
pmdarima/__init__.py:49: in <module>
    from . import __check_build
pmdarima/__check_build/__init__.py:46: in <module>
    raise_build_error(ie)
pmdarima/__check_build/__init__.py:31: in raise_build_error
    raise ImportError("""%s
E   ImportError: No module named 'pmdarima.__check_build._check_build'
E   ___________________________________________________________________________
E   Contents of /Volumes/GoogleDrive/My Drive/1 Projects/pmdarima - update ARIMA.predict ValueError/pmdarima/pmdarima/__check_build:
E   __init__.py               _check_build.pyx          setup.py
E   tests                     __pycache__               _check_build.c
E   ___________________________________________________________________________
E   It seems that pmdarima has not been built correctly.
E   If you have installed pmdarima from source, please do not forget
E   to build the package before using it: run `python setup.py install` or
E   `make` from the top-level directory.
E   
E   If you have used an installer, please check that it is suited for your
E   Python version, your operating system and your platform.
```

I'm using a Macbook pro 2019 v12.4 Monterey, python 3.10.6.
