### PR TITLE
[MRG] Update CI/CD dependencies

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@master
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
           architecture: 'x64'
       - name: Install Requirements
         run: python -m pip install requests

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -9,8 +9,8 @@ jobs:
     name: Update Downloads Badges
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout master
-        uses: actions/checkout@master
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -117,10 +117,10 @@ jobs:
         run: |
           if [ -f "${GITHUB_WORKSPACE}/pmdarima/VERSION" ]; then
             echo "VERSION file exists"
-            echo "::set-output name=version_exists::true"
+            echo "version_exists=true" >> $GITHUB_OUTPUT
           else
             echo "VERSION file does not exist"
-            echo "::set-output name=version_exists::false"
+            echo "version_exists=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Deploying to PyPI

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -40,13 +40,13 @@ jobs:
 
       # Python interpreter used by cibuildwheel, but it uses a different one internally
       - name: Setting up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
 
@@ -56,7 +56,7 @@ jobs:
         run: make version sdist
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.9.0 # TODO: Do we want this pinned?
+        run: python -m pip install cibuildwheel==2.11.2 # TODO: Do we want this pinned?
 
       - name: Building and testing wheels
         run: python -m cibuildwheel --output-dir dist

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -33,10 +33,8 @@ jobs:
     name: Build and Deploy (${{ matrix.os }}, 3.${{ matrix.python3-minor-version }})
 
     steps:
-      # This LOOKS like it is checking out 'master', but it is using the 'master' version of the checkout action
-      # It is actually checking out the most recent version on this branch
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       # Python interpreter used by cibuildwheel, but it uses a different one internally
       - name: Setting up Python

--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: Setting up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setting up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -143,7 +143,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setting up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 

--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -46,13 +46,13 @@ jobs:
 
       - name: Set Run ID
         id: definition  # Needed to retrieve the output of this step later
-        run: echo "::set-output name=run_id::$GITHUB_RUN_ID"
+        run: echo "run_id=$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Collecting naked dependencies
         id: dependencies  # Needed to retrieve the output of this step later
         run: |
           dependencies=$(python build_tools/github/get_latest_dependencies.py)
-          echo "::set-output name=latest_dependencies::$dependencies"
+          echo "latest_dependencies=$dependencies" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Install cibuildwheel
@@ -65,7 +65,7 @@ jobs:
           table=$(python .github/utils/get_dependency_releases.py $DEPENDENCIES)
 
           # This is used in the next job (if necessary) rather than re-running the above
-          echo "::set-output name=table::$table"
+          echo "table=$table" >> $GITHUB_OUTPUT
         env:
           DEPENDENCIES: ${{ steps.dependencies.outputs.latest_dependencies }}
 

--- a/.github/workflows/test_tagging.yml
+++ b/.github/workflows/test_tagging.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setting up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
           architecture: 'x64'
 
       - name: Ensure VERSION tagging works

--- a/.github/workflows/test_tagging.yml
+++ b/.github/workflows/test_tagging.yml
@@ -21,10 +21,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # This LOOKS like it is checking out 'master', but it is using the 'master' version of the checkout action
-      # It is actually checking out the most recent version on this branch
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: Setting up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
# Description

This PR:

- Fixes deprecations in our GitHub Actions workflows by changing `echo "::set-output name=foo::bar"` to `echo "foo=bar" >> $GITHUB_OUTPUT`
- Bumps our `setup-python` action to `v4`
- Bumps our `setup-qemu-action` to `v2`
- Changes `actions/checkout` to use a pinned version (`v3`) instead of `master`
- Updates our `badges` and `test_tagging` workflow to use python `3.11`
    - As an aside, do we still need the `test_tagging` workflow?
- Bumps `cibuildwheel` to `2.11.2`
- Updates our `CITATION.cff` to the latest tag
    - I think I am going to write a workflow that does this on a release. Seems like a cleaner option

## Type of change

- [X] Documentation change
- [X] CI/CD Change 

# How Has This Been Tested?

- [X] Tests still pass on GHA

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
