### PR TITLE
[MRG+1] Fix regression introduced by scikit-learn 1.2.0

### DIFF
--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -247,7 +247,7 @@ class Pipeline(BaseEstimator):
 
                 # TODO: manual check to ensure Xt shape == n_periods shape?
 
-                _, Xt = transformer.transform(y=None, X=Xt, **kw)
+                _, Xt = transformer.transform(None, Xt, **kw)
 
         # since some exog featurizers require exog input, and others don't,
         # feat orders may get wonky between fit & pred. Make sure we have them

--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -533,7 +533,7 @@ class Pipeline(BaseEstimator):
                 yt, Xt = transformer.update_and_transform(
                     y=yt, X=Xt, **kw)
             else:
-                yt, Xt = transformer.transform(yt, X=Xt, **kw)
+                yt, Xt = transformer.transform(yt, Xt, **kw)
 
         if self.x_feats_ is not None:
             Xt = Xt[self.x_feats_]

--- a/pmdarima/preprocessing/endog/tests/test_boxcox.py
+++ b/pmdarima/preprocessing/endog/tests/test_boxcox.py
@@ -19,7 +19,7 @@ loggamma = stats.loggamma.rvs(5, size=500) + 5
 )
 def test_invertible(X):
     trans = BoxCoxEndogTransformer()
-    y_t, e_t = trans.fit_transform(loggamma, X=X)
+    y_t, e_t = trans.fit_transform(loggamma, X)
     y_prime, e_prime = trans.inverse_transform(y_t, X=e_t)
 
     assert_array_almost_equal(loggamma, y_prime)

--- a/pmdarima/preprocessing/exog/tests/test_fourier.py
+++ b/pmdarima/preprocessing/exog/tests/test_fourier.py
@@ -79,7 +79,7 @@ class TestFourierREquivalency:
 
             # Test a bad forecast (X dim does not match n_periods dim)
             with pytest.raises(ValueError):
-                trans.transform(y, X=np.random.rand(5, 3), n_periods=2)
+                trans.transform(y, np.random.rand(5, 3), n_periods=2)
 
 
 def test_hyndman_blog():


### PR DESCRIPTION
# Description

This PR attempts to fix the `TypeError`s showing up in our [nightly builds](https://github.com/alkaline-ml/pmdarima/actions/runs/3655224217/jobs/6176356129). I can't explain why, but removing the keyword args is necessary to get anything that is a subtype of `_SetOutputMixin` to pass

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Tests now pass locally and on CI

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
