### PR TITLE
[MRG] Explicitly set dtype=object when generating permutations

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -80,8 +80,7 @@ jobs:
           # Runs tests and checks for a numpy regression by upgrading numpy and running tests again
           CIBW_TEST_COMMAND: >
             pytest --showlocals --durations=20 --pyargs pmdarima &&
-            pip uninstall --y numpy &&
-            pip install --upgrade numpy &&
+            pip install --upgrade scipy numpy &&
             pytest --showlocals --durations=20 --pyargs pmdarima
           # Avoid testing on emulated architectures
           CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64"

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -80,6 +80,7 @@ jobs:
           # Runs tests and checks for a numpy regression by upgrading numpy and running tests again
           CIBW_TEST_COMMAND: >
             pytest --showlocals --durations=20 --pyargs pmdarima &&
+            pip uninstall --y numpy &&
             pip install --upgrade numpy &&
             pytest --showlocals --durations=20 --pyargs pmdarima
           # Avoid testing on emulated architectures

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -99,8 +99,10 @@ class _RandomFitWrapper(_SolverMixin):
         if random:
             random_state = check_random_state(random_state)
 
-            # make a list to scramble...
-            gen = random_state.permutation(list(gen))[:n_fits]
+            # make a list to scramble... `gen` may have a ragged nested
+            # sequence, so we have to explicitly use dtype='object', otherwise
+            # it will raise a ValueError on numpy >= 1.24
+            gen = random_state.permutation(np.array(list(gen), dtype='object'))[:n_fits]  # noqa: E501
 
         self.gen = gen
         self.n_jobs = n_jobs


### PR DESCRIPTION
# Description

Our nightly build is [failing](https://github.com/alkaline-ml/pmdarima/actions/runs/3738252864/jobs/6344168234) due to [this expired deprecation](https://github.com/numpy/numpy/pull/22004). I think explicitly calling `dtype='object'` should fix it

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Tests run on [numpy < 1.24](https://github.com/alkaline-ml/pmdarima/actions/runs/3743186761/jobs/6355054804#step:7:354)
- [X] Tests run on numpy >= 1.24(https://github.com/alkaline-ml/pmdarima/actions/runs/3743186761/jobs/6355054804#step:7:646)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
