### PR TITLE
[MRG] Remove pkg_resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,9 +120,9 @@ jobs:
         command: |
           echo "0.0.0" > ~/pmdarima/pmdarima/VERSION
 
-          # we'll need numpy and cython to build this. let install_requires do all the
+          # we'll need packaging, numpy, and cython to build this. let install_requires do all the
           # rest of the work. We build with our lowest supported numpy version to make sure there is no regression
-          pip install "numpy~=1.19.3" "cython>=0.29,!=0.29.18,!=0.29.31"
+          pip install "packaging>=17.1" "numpy~=1.19.3" "cython>=0.29,!=0.29.18,!=0.29.31"
           python setup.py sdist
 
           cd dist

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,7 +19,6 @@ concurrency:
 jobs:
   build-and-deploy:
     strategy:
-      fail-fast: false # TODO: Remove
       matrix:
         python3-minor-version: [7, 8, 9, 10, 11]
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   build-and-deploy:
     strategy:
+      fail-fast: false # TODO: Remove
       matrix:
         python3-minor-version: [7, 8, 9, 10, 11]
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -17,6 +17,7 @@ pytest
 pytest-mpl
 pytest-benchmark
 setuptools>=38.6.0,!=50.0.0
+packaging>=17.1  # Bundled with setuptools, but want to be explicit
 wheel
 twine>=1.13.0
 readme_renderer

--- a/pmdarima/compat/sklearn.py
+++ b/pmdarima/compat/sklearn.py
@@ -3,7 +3,7 @@
 # Author: Charles Drotar <drotarcharles@gmail.com>
 #
 # Patch backend for sklearn
-from packaging.version import parse
+from packaging.version import Version
 
 import sklearn
 from sklearn.exceptions import NotFittedError
@@ -90,7 +90,7 @@ def if_delegate_has_method(attr):
     .. [1] https://git.io/JzKiv
     .. [2] https://git.io/JzKiJ
     """
-    if parse(sklearn.__version__) < parse("1.0.0"):
+    if Version(sklearn.__version__) < Version("1.0.0"):
         from sklearn.utils.metaestimators import if_delegate_has_method
         return if_delegate_has_method(attr)
     else:

--- a/pmdarima/compat/sklearn.py
+++ b/pmdarima/compat/sklearn.py
@@ -3,8 +3,7 @@
 # Author: Charles Drotar <drotarcharles@gmail.com>
 #
 # Patch backend for sklearn
-
-from pkg_resources import parse_version
+from packaging.version import parse
 
 import sklearn
 from sklearn.exceptions import NotFittedError
@@ -91,7 +90,7 @@ def if_delegate_has_method(attr):
     .. [1] https://git.io/JzKiv
     .. [2] https://git.io/JzKiJ
     """
-    if parse_version(sklearn.__version__) < parse_version("1.0.0"):
+    if parse(sklearn.__version__) < parse("1.0.0"):
         from sklearn.utils.metaestimators import if_delegate_has_method
         return if_delegate_has_method(attr)
     else:

--- a/pmdarima/compat/statsmodels.py
+++ b/pmdarima/compat/statsmodels.py
@@ -3,7 +3,7 @@
 # Handle inconsistencies in the statsmodels API versions
 
 from collections.abc import Iterable
-from pkg_resources import parse_version
+from packaging.version import parse
 import statsmodels as sm
 
 __all__ = [
@@ -62,4 +62,4 @@ def check_seasonal_order(order):
 
 
 def _use_sm13():
-    return parse_version(sm.__version__) >= parse_version("0.13.0")
+    return parse(sm.__version__) >= parse("0.13.0")

--- a/pmdarima/compat/statsmodels.py
+++ b/pmdarima/compat/statsmodels.py
@@ -3,7 +3,7 @@
 # Handle inconsistencies in the statsmodels API versions
 
 from collections.abc import Iterable
-from packaging.version import parse
+from packaging.version import Version
 import statsmodels as sm
 
 __all__ = [
@@ -62,4 +62,4 @@ def check_seasonal_order(order):
 
 
 def _use_sm13():
-    return parse(sm.__version__) >= parse("0.13.0")
+    return Version(sm.__version__) >= Version("0.13.0")

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -4,7 +4,6 @@
 #
 # Wrapped functions
 from functools import wraps
-from pkg_resources import parse_version
 import warnings
 
 from statsmodels.tsa.stattools import acf as sm_acf, pacf as sm_pacf

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -7,9 +7,6 @@ from functools import wraps
 import warnings
 
 from statsmodels.tsa.stattools import acf as sm_acf, pacf as sm_pacf
-import statsmodels
-
-from pmdarima.compat.statsmodels import _use_sm13
 
 __all__ = [
     'acf',

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scipy>=1.3.2
 statsmodels>=0.13.2
 urllib3
 setuptools>=38.6.0,!=50.0.0
+packaging>=17.1  # Bundled with setuptools, but want to be explicit

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import platform
 import shutil
 
 from distutils.command.clean import clean as Clean
-from pkg_resources import parse_version
+from packaging.version import Version
 from setuptools import find_packages
 import traceback
 import importlib
@@ -189,8 +189,8 @@ def check_package_status(package, min_version):
     try:
         module = importlib.import_module(package)
         package_version = module.__version__
-        package_status['up_to_date'] = parse_version(
-            package_version) >= parse_version(min_version)
+        package_status['up_to_date'] = Version(
+            package_version) >= Version(min_version)
         package_status['version'] = package_version
     except ImportError:
         traceback.print_exc()


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Remove `pkg_resources` because it is [deprecated](https://github.com/pypa/setuptools/pull/3843). Replace with what `pkg_resources.parse_version` calls [under the hood](https://github.com/pypa/setuptools/blob/b010f52705b41cd904813076447da3092776462a/pkg_resources/__init__.py#L134)

## Type of change

- [X] Deprecation fix

# How Has This Been Tested?

- [X] Tests pass on CI

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
