### PR TITLE
[MRG+1] Remove support for Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ commands:
             -v `pwd`:/app \
             -w /app \
             --env-file vars.env \
-            python:3.7 \
+            python:3.9 \
             ./build_tools/circle/deploy.sh
 
 jobs:
@@ -94,7 +94,7 @@ jobs:
   # larger unit tests, and to avoid multiple setup steps that can slow the pipeline down
   test-sanity:
     docker:
-      - image: python:3.7
+      - image: python:3.9
     working_directory: ~/pmdarima
     steps:
     - checkout
@@ -130,26 +130,6 @@ jobs:
           python -c 'import pmdarima as pm; print(pm.__version__)'
 
   # --- Unit tests ---
-  # These are all executed on `machine` executors, since they require DinD to build the whl
-  # files and perform the whl repair for manylinux support.
-  test-unit-cpython37:
-    machine:
-      image: ubuntu-2004:202111-02
-    working_directory: ~/pmdarima
-    steps:
-      - checkout
-      - build-test-and-persist:
-          pythonversion: "3.7"
-
-  test-unit-cpython38:
-    machine:
-      image: ubuntu-2004:202111-02
-    working_directory: ~/pmdarima
-    steps:
-      - checkout
-      - build-test-and-persist:
-          pythonversion: "3.8"
-
   test-unit-cpython39:
     machine:
       image: ubuntu-2004:202111-02
@@ -219,16 +199,6 @@ jobs:
   #
   # ############################################
 
-  deploy-cpython37-whl:
-    machine:
-      image: ubuntu-2004:202111-02
-    working_directory: ~/pmdarima
-    steps:
-      - checkout
-      - restore-whl-file:
-          key: "3.7"
-      - deploy-to-pypi
-
   deploy-cpython38-whl:
     machine:
       image: ubuntu-2004:202111-02
@@ -287,7 +257,7 @@ jobs:
   # GH_TOKEN (the personal Git token with pushes enabled)
   deploy-doc:
     docker:
-      - image: python:3.7
+      - image: python:3.9
     working_directory: ~/pmdarima
     steps:
       - checkout
@@ -306,10 +276,6 @@ workflows:
         # run on test and tag
         - test-sanity:
             filters: *test-filters
-        - test-unit-cpython37:
-            filters: *test-filters
-        - test-unit-cpython38:
-            filters: *test-filters
         - test-unit-cpython39:
             filters: *test-filters
         - test-unit-cpython310:
@@ -323,8 +289,6 @@ workflows:
         - testing-passed:
             requires:
                 - test-sanity
-                - test-unit-cpython37
-                - test-unit-cpython38
                 - test-unit-cpython39
                 - test-unit-cpython310
                 - test-unit-cpython311
@@ -338,16 +302,6 @@ workflows:
                 - build-doc
                 - testing-passed
             filters: *test-filters
-
-        - deploy-cpython37-whl:
-            filters: *deploy-filters
-            requires:
-                - deploy-doc
-
-        - deploy-cpython38-whl:
-            filters: *deploy-filters
-            requires:
-              - deploy-doc
 
         - deploy-cpython39-whl:
             filters: *deploy-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,8 @@ jobs:
     docker:
       - image: python:3.9
     working_directory: ~/pmdarima
+    environment:
+      SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
     - checkout
     - run:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,7 +20,7 @@ jobs:
   build-and-deploy:
     strategy:
       matrix:
-        python3-minor-version: [9, 10, 11]
+        python3-minor-version: [9, 10, 11, 12]
         # TODO: Figure out macos-14/macos-latest
         os: [macos-13, ubuntu-latest, windows-latest]
     defaults:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,7 +20,7 @@ jobs:
   build-and-deploy:
     strategy:
       matrix:
-        python3-minor-version: [7, 8, 9, 10, 11, 12]
+        python3-minor-version: [9, 10, 11]
         # TODO: Figure out macos-14/macos-latest
         os: [macos-13, ubuntu-latest, windows-latest]
     defaults:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CircleCI](https://circleci.com/gh/alkaline-ml/pmdarima.svg?style=svg)](https://circleci.com/gh/alkaline-ml/pmdarima)
 [![Github Actions Status](https://github.com/alkaline-ml/pmdarima/workflows/Mac%20and%20Windows%20Builds/badge.svg?branch=master)](https://github.com/alkaline-ml/pmdarima/actions?query=workflow%3A%22Mac+and+Windows+Builds%22+branch%3Amaster)
 [![codecov](https://codecov.io/gh/alkaline-ml/pmdarima/branch/master/graph/badge.svg)](https://codecov.io/gh/alkaline-ml/pmdarima)
-![Supported versions](https://img.shields.io/badge/python-3.7+-blue.svg)
+![Supported versions](https://img.shields.io/badge/python-3.9+-blue.svg)
 ![Downloads](https://img.shields.io/badge/dynamic/json?color=blue&label=downloads&query=%24.total&url=https%3A%2F%2Fstore.zapier.com%2Fapi%2Frecords%3Fsecret%3D1e061b29db6c4f15af01103d403b0237)
 ![Downloads/Week](https://img.shields.io/badge/dynamic/json?color=blue&label=downloads%2Fweek&query=%24.weekly&url=https%3A%2F%2Fstore.zapier.com%2Fapi%2Frecords%3Fsecret%3D1e061b29db6c4f15af01103d403b0237)
 
@@ -118,7 +118,7 @@ with open('model.pkl', 'rb') as pkl:
 
 ### Availability
 
-`pmdarima` is available on PyPi in pre-built Wheel files for Python 3.7+ for the following platforms:
+`pmdarima` is available on PyPi in pre-built Wheel files for Python 3.9+ for the following platforms:
 
 * Mac (64-bit)
 * Linux (64-bit manylinux)

--- a/build_tools/circle/build_wheel.sh
+++ b/build_tools/circle/build_wheel.sh
@@ -9,9 +9,7 @@ function build_wheel {
 
     # https://www.python.org/dev/peps/pep-0513/#ucs-2-vs-ucs-4-builds
     ucs_tag=""
-    if [ "$pyver" = "3.7" ]; then
-        ucs_tag="m"
-    elif [ "$ucs_setting" = "ucs4" ]; then
+    if [ "$ucs_setting" = "ucs4" ]; then
         ucs_tag="${ucs_tag}u"
     fi
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -224,7 +224,7 @@ sphinx_gallery_conf = {
 def setup(app):
     def adds(pth):
         print("Adding stylesheet: %s" % pth)
-        app.add_stylesheet(pth)
+        app.add_css_file(pth)
 
     adds('css/fields.css')  # for parameters, etc.
     adds('css/gitcontrib.css')  # for git contributors

--- a/doc/sg_execution_times.rst
+++ b/doc/sg_execution_times.rst
@@ -1,0 +1,73 @@
+
+:orphan:
+
+.. _sphx_glr_sg_execution_times:
+
+
+Computation times
+=================
+**00:11.856** total execution time for 13 files **from all galleries**:
+
+.. container::
+
+  .. raw:: html
+
+    <style scoped>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" rel="stylesheet" />
+    </style>
+    <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script type="text/javascript" class="init">
+    $(document).ready( function () {
+        $('table.sg-datatable').DataTable({order: [[1, 'desc']]});
+    } );
+    </script>
+
+  .. list-table::
+   :header-rows: 1
+   :class: table table-striped sg-datatable
+
+   * - Example
+     - Time
+     - Mem (MB)
+   * - :ref:`sphx_glr_auto_examples_preprocessing_example_date_featurizer.py` (``../examples/preprocessing/example_date_featurizer.py``)
+     - 00:03.490
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_example_simple_fit.py` (``../examples/example_simple_fit.py``)
+     - 00:03.400
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_model_selection_example_cross_val_predict.py` (``../examples/model_selection/example_cross_val_predict.py``)
+     - 00:01.976
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_example_pipeline.py` (``../examples/example_pipeline.py``)
+     - 00:00.937
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_model_selection_example_cross_validation.py` (``../examples/model_selection/example_cross_validation.py``)
+     - 00:00.775
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_arima_example_persisting_a_model.py` (``../examples/arima/example_persisting_a_model.py``)
+     - 00:00.602
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_utils_example_tsdisplay.py` (``../examples/utils/example_tsdisplay.py``)
+     - 00:00.233
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_arima_example_add_new_samples.py` (``../examples/arima/example_add_new_samples.py``)
+     - 00:00.198
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_arima_example_seasonal_decomposition.py` (``../examples/arima/example_seasonal_decomposition.py``)
+     - 00:00.140
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_arima_example_auto_arima.py` (``../examples/arima/example_auto_arima.py``)
+     - 00:00.102
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_datasets_example_load_data.py` (``../examples/datasets/example_load_data.py``)
+     - 00:00.001
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_utils_example_array_differencing.py` (``../examples/utils/example_array_differencing.py``)
+     - 00:00.001
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_utils_example_array_concatenation.py` (``../examples/utils/example_array_concatenation.py``)
+     - 00:00.000
+     - 0.0

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,12 +7,16 @@ What's new in pmdarima
 As new releases of pmdarima are pushed out, the following list (introduced in
 v0.8.1) will document the latest features.
 
+`v2.0.5 <https://alkaline-ml.com/pmdarima/2.0.5>`_
+-------------------------------------------------
+
+* Remove support for Python 3.7 (end-of-life 2023-06-23)
+* Remove support for Python 3.8 (end-of-life 2024-10-07)
+
 `v2.0.4 <https://alkaline-ml.com/pmdarima/2.0.4>`_
 -------------------------------------------------
 
 * Pin numpy to ``<2.0.0`` while work is done to support numpy ``>=2.0.0``
-* Remove support for Python 3.7 (end-of-life 2023-06-23)
-* Remove support for Python 3.8 (end-of-life 2024-10-07)
 
 `v2.0.3 <https://alkaline-ml.com/pmdarima/2.0.3>`_
 -------------------------------------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,8 @@ v0.8.1) will document the latest features.
 -------------------------------------------------
 
 * Pin numpy to ``<2.0.0`` while work is done to support numpy ``>=2.0.0``
+* Remove support for Python 3.7 (end-of-life 2023-06-23)
+* Remove support for Python 3.8 (end-of-life 2024-10-07)
 
 `v2.0.3 <https://alkaline-ml.com/pmdarima/2.0.3>`_
 -------------------------------------------------

--- a/pmdarima/arima/tests/test_arima_diagnostics.py
+++ b/pmdarima/arima/tests/test_arima_diagnostics.py
@@ -76,8 +76,8 @@ def mock_acf_plot(resid, ax, lags):
 def test_mock_plot_diagnostics(model_type, model):
     model.fit(lynx)
 
-    with patch('statsmodels.graphics.utils.create_mpl_fig', MockMPLFigure),\
-            patch('statsmodels.graphics.gofplots.qqplot', mock_qqplot),\
+    with patch('statsmodels.graphics.utils.create_mpl_fig', MockMPLFigure), \
+            patch('statsmodels.graphics.gofplots.qqplot', mock_qqplot), \
             patch('statsmodels.graphics.tsaplots.plot_acf', mock_acf_plot):
 
         diag = model.plot_diagnostics(figsize=(10, 12))

--- a/pmdarima/datasets/tests/test_load_datasets.py
+++ b/pmdarima/datasets/tests/test_load_datasets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from pmdarima.datasets import load_heartrate, load_lynx, load_wineind,\
+from pmdarima.datasets import load_heartrate, load_lynx, load_wineind, \
     load_woolyrnq, load_ausbeer, load_austres, load_gasoline, \
     load_airpassengers, load_taylor, load_msft, load_sunspots, _base as base
 

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ import importlib
 import builtins
 
 # Minimum allowed version
-MIN_PYTHON = (3, 7)
 IS_PYTHON_312 = sys.version_info[0] == 3 and sys.version_info[1] >= 12
+MIN_PYTHON = (3, 9)
 
 # Hacky (!!), adopted from sklearn. This sets a global variable
 # so pmdarima __init__ can detect if it's being loaded in the setup
@@ -239,7 +239,6 @@ def do_setup():
                         'Operating System :: Unix',
                         'Operating System :: MacOS',
                         'Programming Language :: Python :: 3',
-                        'Programming Language :: Python :: 3.7',
                         'Programming Language :: Python :: 3.8',
                         'Programming Language :: Python :: 3.9',
                         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -239,7 +239,6 @@ def do_setup():
                         'Operating System :: Unix',
                         'Operating System :: MacOS',
                         'Programming Language :: Python :: 3',
-                        'Programming Language :: Python :: 3.8',
                         'Programming Language :: Python :: 3.9',
                         'Programming Language :: Python :: 3.10',
                         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
# Description

Python 3.7 is due to be [end-of-lifed on June 27, 2023](https://endoflife.date/python). This PR preps us to remove support for it.

Think this will depend on https://github.com/alkaline-ml/pmdarima-docker/pull/26

## Type of change

- [X] Python version removal

# How Has This Been Tested?

3.7 tests no longer exist, everything else still works

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
