### PR TITLE
[MRG+1] Change how we implement show_versions()

### DIFF
--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '0 7 * * *'  # Every day at 07:00 UTC (1AM CST or 2AM CDT)
 
+  # Allows us to run manually
+  workflow_dispatch:
+
 # Cancel older runs of the same workflow on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/pmdarima/utils/_show_versions.py
+++ b/pmdarima/utils/_show_versions.py
@@ -4,13 +4,13 @@ Utility methods to print system info for debugging
 adapted from ``pandas.show_versions``
 adapted from ``sklearn.show_versions``
 """
-import os
 # License: BSD 3 clause
 
 import platform
 import sys
 
 _pmdarima_deps = (
+    # setuptools needs to be before pip: https://github.com/pypa/setuptools/issues/3044#issuecomment-1024972548 # noqa:E501
     "setuptools",
     "pip",
     "sklearn",
@@ -57,6 +57,9 @@ def _get_deps_info(deps=_pmdarima_deps):
     deps_info: dict
         version information on relevant Python libraries
     """
+    def get_version(module):
+        return module.__version__
+
     deps_info = {}
 
     # TODO: We can get rid of this when we deprecate 3.7
@@ -69,8 +72,8 @@ def _get_deps_info(deps=_pmdarima_deps):
                     mod = sys.modules[modname]
                 else:
                     mod = importlib.import_module(modname)
-
-                deps_info[modname] = mod.__version__
+                ver = get_version(mod)
+                deps_info[modname] = ver
             except ImportError:
                 deps_info[modname] = None
 
@@ -79,7 +82,7 @@ def _get_deps_info(deps=_pmdarima_deps):
 
         for modname in deps:
             try:
-                deps_info[modname] = version(_install_mapping.get(modname, modname))
+                deps_info[modname] = version(_install_mapping.get(modname, modname))  # noqa:E501
             except PackageNotFoundError:
                 deps_info[modname] = None
 

--- a/pmdarima/utils/_show_versions.py
+++ b/pmdarima/utils/_show_versions.py
@@ -11,8 +11,8 @@ import platform
 import sys
 
 _pmdarima_deps = (
-    "pip",
     "setuptools",
+    "pip",
     "sklearn",
     "statsmodels",
     "numpy",
@@ -62,10 +62,6 @@ def _get_deps_info(deps=_pmdarima_deps):
     # TODO: We can get rid of this when we deprecate 3.7
     if sys.version_info.minor <= 7:
         import importlib
-
-        # Needed if pip is imported before setuptools
-        # https://github.com/pypa/setuptools/issues/3044#issuecomment-1024972548 # noqa:E501
-        os.environ["SETUPTOOLS_USE_DISTUTILS"] = "stdlib"
 
         for modname in deps:
             try:

--- a/pmdarima/utils/_show_versions.py
+++ b/pmdarima/utils/_show_versions.py
@@ -8,7 +8,6 @@ adapted from ``sklearn.show_versions``
 
 import platform
 import sys
-import importlib
 
 _pmdarima_deps = (
     "pip",
@@ -52,22 +51,15 @@ def _get_deps_info(deps=_pmdarima_deps):
     deps_info: dict
         version information on relevant Python libraries
     """
-    def get_version(module):
-        return module.__version__
-
     deps_info = {}
+
+    from importlib.metadata import PackageNotFoundError, version
 
     for modname in deps:
         try:
-            if modname in sys.modules:
-                mod = sys.modules[modname]
-            else:
-                mod = importlib.import_module(modname)
-            ver = get_version(mod)
-            deps_info[modname] = ver
-        except ImportError:
+            deps_info[modname] = version(modname)
+        except PackageNotFoundError:
             deps_info[modname] = None
-
     return deps_info
 
 

--- a/pmdarima/utils/_show_versions.py
+++ b/pmdarima/utils/_show_versions.py
@@ -56,8 +56,15 @@ def _get_deps_info(deps=_pmdarima_deps):
     from importlib.metadata import PackageNotFoundError, version
 
     for modname in deps:
+        # Gotta do a little correction for scikit
+        normalized_modname: str
+        if modname == "sklearn":
+            normalized_modname = "scikit-learn"
+        else:
+            normalized_modname = modname
+
         try:
-            deps_info[modname] = version(modname)
+            deps_info[modname] = version(normalized_modname)
         except PackageNotFoundError:
             deps_info[modname] = None
     return deps_info

--- a/pmdarima/utils/_show_versions.py
+++ b/pmdarima/utils/_show_versions.py
@@ -54,7 +54,7 @@ def _get_deps_info(deps=_pmdarima_deps):
     deps_info = {}
 
     # TODO: We can get rid of this when we deprecate 3.7
-    if platform.python_version() < '3.8':
+    if sys.version_info.minor <= 7:
         import importlib
 
         def get_version(module):

--- a/pmdarima/utils/_show_versions.py
+++ b/pmdarima/utils/_show_versions.py
@@ -64,7 +64,7 @@ def _get_deps_info(deps=_pmdarima_deps):
         import importlib
 
         # Needed if pip is imported before setuptools
-        # https://github.com/pypa/setuptools/issues/3044#issuecomment-1024972548
+        # https://github.com/pypa/setuptools/issues/3044#issuecomment-1024972548 # noqa:E501
         os.environ["SETUPTOOLS_USE_DISTUTILS"] = "stdlib"
 
         for modname in deps:


### PR DESCRIPTION
# Description

Hopefully fixes the nightly build. Just took this implementation from [here](https://github.com/scikit-learn/scikit-learn/blob/b88b53985d9ddf8cec60414934c55a5745e8b958/sklearn/utils/_show_versions.py#L36-L71). Output still looks like this:

```
>>> import pmdarima
>>> pmdarima.show_versions()

System:
    python: 3.10.6 (main, Sep 18 2022, 13:28:34) [Clang 13.1.6 (clang-1316.0.21.2.5)]
executable: /Users/asmith/.pyenv/versions/3.10.6/bin/python
   machine: macOS-13.4.1-arm64-arm-64bit

Python dependencies:
 setuptools: 63.2.0
        pip: 23.0.1
    sklearn: 1.2.0
statsmodels: 0.13.2
      numpy: 1.23.3
      scipy: 1.9.1
     Cython: 0.29.32
     pandas: 1.4.4
     joblib: 1.2.0
   pmdarima: 0.0.0
```

One difference is `seuptools` is before `pip` now in the output, due to [this](https://github.com/pypa/setuptools/issues/3044#issuecomment-1024972548)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Nightly build passes
- [X] `show_versions()` still works

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
