### PR TITLE
[MRG] Bump statsmodels to 0.14.0

### DIFF
--- a/build_tools/build_requirements.txt
+++ b/build_tools/build_requirements.txt
@@ -7,8 +7,8 @@ scipy==1.5.3; python_version <= '3.8' and platform_machine == 'aarch64'
 scipy==1.5.4; python_version == '3.9'
 scipy==1.7.2; python_version == '3.10'
 scipy==1.9.3; python_version == '3.11'
-statsmodels==0.13.2; python_version <= '3.10'
-statsmodels==0.13.3; python_version == '3.11'
+statsmodels==0.14.0; python_version <= '3.10'
+statsmodels==0.14.0; python_version == '3.11'
 cython>=0.29,!=0.29.18,!=0.29.31
 scikit-learn>=0.22
 pandas>=0.19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ requires = [
     "scipy==1.5.4; python_version == '3.9'",
     "scipy==1.7.2; python_version == '3.10'",
     "scipy==1.9.3; python_version == '3.11'",
-    "statsmodels==0.13.2; python_version <= '3.10'",
-    "statsmodels==0.13.3; python_version == '3.11'",
+    "statsmodels==0.14.0; python_version <= '3.10'",
+    "statsmodels==0.14.0; python_version == '3.11'",
     "cython>=0.29,!=0.29.18,!=0.29.31",
     "setuptools",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy>=1.21.2
 pandas>=0.19
 scikit-learn>=0.22
 scipy>=1.3.2
-statsmodels>=0.13.2
+statsmodels>=0.14.0
 urllib3
 setuptools>=38.6.0,!=50.0.0
 packaging>=17.1  # Bundled with setuptools, but want to be explicit


### PR DESCRIPTION

# Description

Bumps the required version of statsmodels from 0.13.2 to 0.14.0. This was done as part of debugging #480, and should close #492
