### PR TITLE
[MRG] Fix nightly build

### DIFF
--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -27,8 +27,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ['3.11']
-        python-executable: ['cp311']
+        python-version: ['3.12']
+        python-executable: ['cp312']
     defaults:
       run:
         shell: bash

--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -78,6 +78,7 @@ jobs:
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: "x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
+          CIBW_BEFORE_ALL: make version
           CIBW_BEFORE_BUILD: >
             for dependency in ${{ steps.dependencies.outputs.latest_dependencies }}; do
               pip install $dependency

--- a/.github/workflows/nightly_cron.yml
+++ b/.github/workflows/nightly_cron.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.9.0 # TODO: Do we want this pinned?
+        run: python -m pip install cibuildwheel
 
       - name: Generating dependency table
         id: dependency-table  # Needed to set output of job

--- a/pmdarima/arima/tests/test_validation.py
+++ b/pmdarima/arima/tests/test_validation.py
@@ -202,5 +202,6 @@ def test_warn_for_D(d, D, expected):
 
     else:
         with warnings.catch_warnings():
-            warnings.simplefilter("error")  # Ensure no warnings are emitted if not expected
+            # Ensure no warnings are emitted if not expected
+            warnings.simplefilter("error")
             val.warn_for_D(d=d, D=D)

--- a/pmdarima/arima/tests/test_validation.py
+++ b/pmdarima/arima/tests/test_validation.py
@@ -42,7 +42,7 @@ def test_check_information_criterion(ic,
             assert any('information_criterion cannot be' in s
                        for s in pytest_warning_messages(w))
         else:
-            with pytest.warns(None) as w:
+            with pytest.catch_warnings() as w:
                 res = val.check_information_criterion(ic, ooss)
             assert not w
 
@@ -90,7 +90,7 @@ def test_check_m(m, seasonal, expect_error, expect_warning, expected_val):
             assert any('set for non-seasonal fit' in s
                        for s in pytest_warning_messages(w))
         else:
-            with pytest.warns(None) as w:
+            with pytest.catch_warnings() as w:
                 res = val.check_m(m, seasonal)
             assert not w
 
@@ -114,7 +114,7 @@ def test_check_n_jobs(stepwise, n_jobs, expect_warning, expected_n_jobs):
         assert any('stepwise model cannot be fit in parallel' in s
                    for s in pytest_warning_messages(w))
     else:
-        with pytest.warns(None) as w:
+        with pytest.catch_warnings() as w:
             res = val.check_n_jobs(stepwise, n_jobs)
         assert not w
 
@@ -199,5 +199,5 @@ def test_warn_for_D(d, D, expected):
             assert any(expected in w for w in warning_msgs)
 
     else:
-        with pytest.warns(None):
+        with pytest.catch_warnings():
             val.warn_for_D(d=d, D=D)

--- a/pmdarima/arima/tests/test_validation.py
+++ b/pmdarima/arima/tests/test_validation.py
@@ -201,5 +201,5 @@ def test_warn_for_D(d, D, expected):
             assert any(expected in w for w in warning_msgs)
 
     else:
-        with pytest.catch_warnings(record=True):
+        with warnings.catch_warnings(record=True):
             val.warn_for_D(d=d, D=D)

--- a/pmdarima/arima/tests/test_validation.py
+++ b/pmdarima/arima/tests/test_validation.py
@@ -201,5 +201,6 @@ def test_warn_for_D(d, D, expected):
             assert any(expected in w for w in warning_msgs)
 
     else:
-        with warnings.catch_warnings(record=True):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # Ensure no warnings are emitted if not expected
             val.warn_for_D(d=d, D=D)

--- a/pmdarima/arima/tests/test_validation.py
+++ b/pmdarima/arima/tests/test_validation.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -42,7 +44,7 @@ def test_check_information_criterion(ic,
             assert any('information_criterion cannot be' in s
                        for s in pytest_warning_messages(w))
         else:
-            with pytest.catch_warnings() as w:
+            with warnings.catch_warnings(record=True) as w:
                 res = val.check_information_criterion(ic, ooss)
             assert not w
 
@@ -90,7 +92,7 @@ def test_check_m(m, seasonal, expect_error, expect_warning, expected_val):
             assert any('set for non-seasonal fit' in s
                        for s in pytest_warning_messages(w))
         else:
-            with pytest.catch_warnings() as w:
+            with warnings.catch_warnings(record=True) as w:
                 res = val.check_m(m, seasonal)
             assert not w
 
@@ -114,7 +116,7 @@ def test_check_n_jobs(stepwise, n_jobs, expect_warning, expected_n_jobs):
         assert any('stepwise model cannot be fit in parallel' in s
                    for s in pytest_warning_messages(w))
     else:
-        with pytest.catch_warnings() as w:
+        with warnings.catch_warnings(record=True) as w:
             res = val.check_n_jobs(stepwise, n_jobs)
         assert not w
 
@@ -199,5 +201,5 @@ def test_warn_for_D(d, D, expected):
             assert any(expected in w for w in warning_msgs)
 
     else:
-        with pytest.catch_warnings():
+        with pytest.catch_warnings(record=True):
             val.warn_for_D(d=d, D=D)


### PR DESCRIPTION
# Description

This PR fixes the nightly build by removing the use of `pytest.warns(None)` since it has been removed in pytest 8. It also bumps the Python version for nightly to 3.12

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue

# How Has This Been Tested?

- [X] Nightly tests work no

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
