### PR TITLE
[MRG] doc: clarify that ndiffs/nsdiffs return the minimum d/D, not the maximum (#586)

### DIFF
--- a/pmdarima/arima/tests/test_utils.py
+++ b/pmdarima/arima/tests/test_utils.py
@@ -32,3 +32,38 @@ def test_issue_351():
     warnings_messages = pytest_warning_messages(w_list)
     assert len(warnings_messages) == 1
     assert 'shorter than m' in warnings_messages[0]
+
+
+def test_issue_586_ndiffs_returns_minimum_not_maximum():
+    """Documents the contract clarified in #586: ndiffs returns the SMALLEST
+    d (capped at max_d) at which the stationarity test stops requiring more
+    differencing — i.e. the standard "minimum d for stationarity" you'd want
+    to avoid over-differencing. The previous docstring claimed it returned
+    the *maximum* such d, which would be max_d any time the series became
+    stationary at any point — not what the loop actually does."""
+    rng = np.random.RandomState(0)
+
+    # Stationary series (white noise around zero): test should not ask for
+    # any differencing, so d = 0. Under a "maximum d" reading we'd expect
+    # max_d=2 here, which is the misreading #586 was complaining about.
+    stationary = rng.randn(200)
+    assert arima_utils.ndiffs(stationary, test='kpss', max_d=2) == 0
+    assert arima_utils.ndiffs(stationary, test='adf', max_d=2) == 0
+
+    # Random walk (cumulative sum of noise): non-stationary in levels,
+    # stationary after one difference, so d == 1, NOT max_d.
+    walk = np.cumsum(rng.randn(200))
+    assert arima_utils.ndiffs(walk, test='kpss', max_d=3) == 1
+
+
+def test_issue_586_nsdiffs_returns_minimum_not_maximum():
+    """Companion to test_issue_586_ndiffs_returns_minimum_not_maximum — the
+    same minimum-not-maximum semantics apply to seasonal differencing."""
+    rng = np.random.RandomState(1)
+
+    # Non-seasonal series → OCSB should return D = 0 (no seasonal
+    # differencing required). Under the old "maximum D" reading we'd
+    # expect max_D, which would clearly be wrong.
+    nonseasonal = rng.randn(120)
+    D = arima_utils.nsdiffs(nonseasonal, m=12, max_D=2, test='ocsb')
+    assert D == 0

--- a/pmdarima/arima/utils.py
+++ b/pmdarima/arima/utils.py
@@ -62,8 +62,11 @@ def nsdiffs(x, m, max_D=2, test='ocsb', **kwargs):
 
     Perform a test of seasonality for different levels of ``D`` to
     estimate the number of seasonal differences required to make a given time
-    series stationary. Will select the maximum value of ``D`` for which
-    the time series is judged seasonally stationary by the statistical test.
+    series stationary. Returns the smallest value of ``D`` (capped at
+    ``max_D``) for which the series is judged seasonally stationary by the
+    statistical test — ``D`` is incremented from 0 only as long as the test
+    still asks for more differencing. This matches R ``forecast::nsdiffs``
+    behaviour and is the standard convention to avoid over-differencing.
 
     Parameters
     ----------
@@ -87,9 +90,10 @@ def nsdiffs(x, m, max_D=2, test='ocsb', **kwargs):
     Returns
     -------
     D : int
-        The estimated seasonal differencing term. This is the maximum value
-        of ``D`` such that ``D <= max_D`` and the time series is judged
-        seasonally stationary. If the time series is constant, will return 0.
+        The estimated seasonal differencing term. This is the smallest value
+        of ``D`` (with ``0 <= D <= max_D``) at which the seasonality test
+        stops requiring further differencing. If the time series is
+        constant, will return 0.
     """
     if max_D <= 0:
         raise ValueError('max_D must be a positive integer')
@@ -130,8 +134,11 @@ def ndiffs(x, alpha=0.05, test='kpss', max_d=2, **kwargs):
 
     Perform a test of stationarity for different levels of ``d`` to
     estimate the number of differences required to make a given time
-    series stationary. Will select the maximum value of ``d`` for which
-    the time series is judged stationary by the statistical test.
+    series stationary. Returns the smallest value of ``d`` (capped at
+    ``max_d``) for which the series is judged stationary by the unit-root
+    test — ``d`` is incremented from 0 only as long as the test still asks
+    for more differencing. This matches R ``forecast::ndiffs`` behaviour and
+    is the standard convention to avoid over-differencing.
 
     Parameters
     ----------
@@ -154,9 +161,10 @@ def ndiffs(x, alpha=0.05, test='kpss', max_d=2, **kwargs):
     Returns
     -------
     d : int
-        The estimated differencing term. This is the maximum value of ``d``
-        such that ``d <= max_d`` and the time series is judged stationary.
-        If the time series is constant, will return 0.
+        The estimated differencing term. This is the smallest value of
+        ``d`` (with ``0 <= d <= max_d``) at which the unit-root test stops
+        requiring further differencing. If the time series is constant,
+        will return 0.
 
     References
     ----------


### PR DESCRIPTION
# Description

The docstrings of `pmdarima.arima.ndiffs` and `pmdarima.arima.nsdiffs`
both claim they return the **maximum** value of `d`/`D` for which the
series is judged stationary by the test. That's the opposite of what the
code does and the opposite of the convention you'd want — over-
differencing is what we're trying to avoid.

Reading `pmdarima/arima/utils.py:188-209` (and the seasonal sibling at
`utils.py:105-125`), the loop is:

```python
d = 0
pval, dodiff = testfunc(x)
while dodiff and d < max_d:
    d += 1
    x = diff(x)
    ...
    pval, dodiff = testfunc(x)
return d
```

i.e. `d` is incremented **only as long as the unit-root test still asks
for more differencing**. The returned value is the **smallest** `d` (capped
at `max_d`) at which the test stops asking. This matches R's
[`forecast::ndiffs`](https://github.com/robjhyndman/forecast/blob/19b0711e/R/arima.R#L132)
which is referenced in the existing docstring.

This PR rewords the docstrings of both `ndiffs` and `nsdiffs` to match
the actual code, and adds equivalence tests that pin the contract going
forward — if the code is ever rewritten, those tests will catch a
regression that flips the semantics.

Fixes #586

## Type of change

- [x] Documentation change
- [x] (no behavioural change — the existing code already had the right
      behaviour; only the docstrings were wrong)

## How Has This Been Tested?

```bash
pytest pmdarima/arima/tests/test_utils.py -v
```

→ 4 passed (the 2 existing tests + 2 new equivalence tests). The new
tests pass on `origin/master` too because they assert the contract the
code already implements — they exist to keep the docstring honest.

# Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/alkaline-ml/pmdarima.git /tmp/repro && cd /tmp/repro
python -m venv .venv && source .venv/bin/activate
pip install -e .

# --- BEFORE (origin/master) — read the docstring ---
git checkout origin/master
python -c "
from pmdarima.arima.utils import ndiffs
print(ndiffs.__doc__.split('Parameters')[0])
"
# Expected: docstring says "Will select the maximum value of d for which
#           the time series is judged stationary"

# Demonstrate the docstring is wrong: a stationary series gets d=0,
# not max_d=2 (which a "maximum" reading would imply).
python -c "
import numpy as np
from pmdarima.arima.utils import ndiffs
np.random.seed(0)
y = np.random.randn(200)              # stationary white noise
print('ndiffs(stationary, max_d=2) =', ndiffs(y, test='kpss', max_d=2))
"
# Expected: 0   ← contradicts the "maximum d such that ... stationary" wording

# --- AFTER (this PR) — same code path, corrected docstring + tests ---
git fetch https://github.com/jbbqqf/pmdarima.git feat/586-ndiffs-docstring-fix
git checkout FETCH_HEAD
python -c "
from pmdarima.arima.utils import ndiffs
print(ndiffs.__doc__.split('Parameters')[0])
"
# Expected: docstring now says "smallest value of d ... at which the
#           unit-root test stops requiring further differencing"

pytest pmdarima/arima/tests/test_utils.py -v
# Expected: 4 passed, including
#   test_issue_586_ndiffs_returns_minimum_not_maximum
#   test_issue_586_nsdiffs_returns_minimum_not_maximum
```

# Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Stationary series, KPSS | white noise, `max_d=2` | `d == 0` | `test_issue_586_ndiffs_returns_minimum_not_maximum` |
| 2 | Stationary series, ADF | white noise, `max_d=2` | `d == 0` | `test_issue_586_ndiffs_returns_minimum_not_maximum` |
| 3 | Random walk | cumsum(noise), `max_d=3` | `d == 1` (not `max_d=3`) | `test_issue_586_ndiffs_returns_minimum_not_maximum` |
| 4 | Non-seasonal series for `nsdiffs` | white noise, `m=12`, `max_D=2` | `D == 0` | `test_issue_586_nsdiffs_returns_minimum_not_maximum` |

# Risk / blast radius

Docstring text + a single test file. No production code path touched.
Existing `test_issue_341` and `test_issue_351` still pass unchanged.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

```release-note
Doc fix: clarify that `ndiffs` and `nsdiffs` return the minimum d/D needed for stationarity, not the maximum (#586).
```

---

*PR drafted with assistance from Claude Code. Reviewed manually against
`pmdarima/arima/utils.py` and the cited R `forecast::ndiffs`
implementation. Reproducer block above was used during development.*
