### PR TITLE
[MRG] arima: warn on deprecated exog kwarg instead of silently swallowing it (#530)

### DIFF
--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -43,6 +43,36 @@ _CHECK_ARRAY_FINITE_PARAM = (
 )
 
 
+def _resolve_legacy_exog_kwarg(method_name, X, kwargs):
+    """Issue #530: ``ARIMA.fit`` / ``predict`` / ``update`` historically
+    accepted ``exog`` as the name of the exogenous-features argument. In
+    pmdarima 2.0 it was renamed to ``X``, but the methods still take
+    ``**fit_args`` / ``**kwargs`` for forwarding to statsmodels, so a
+    caller passing ``exog=foo`` had it silently swallowed and dropped —
+    statsmodels' fit signature does not take ``exog`` either, so the
+    intended exogenous matrix was never used and predictions silently
+    came out wrong. Pop ``exog`` here, raise on conflict with ``X``,
+    emit a ``DeprecationWarning``, and return the resolved ``X`` so the
+    caller proceeds as if the user had passed ``X``."""
+    if "exog" not in kwargs:
+        return X
+    legacy = kwargs.pop("exog")
+    if X is not None:
+        raise TypeError(
+            f"{method_name}() got both `X` and the deprecated alias `exog`; "
+            f"pass only `X` (the `exog` keyword was renamed in pmdarima 2.0)."
+        )
+    warnings.warn(
+        f"The `exog` keyword to {method_name}() was renamed to `X` in "
+        f"pmdarima 2.0. The legacy name still works for now but is "
+        f"silently swallowed when passed via **kwargs in older builds; "
+        f"please update your call to use `X=...` instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return legacy
+
+
 def ARMAtoMA(ar, ma, max_deg):
     r"""
     Convert ARMA coefficients to infinite MA coefficients.
@@ -570,6 +600,10 @@ class ARIMA(BaseARIMA):
         **fit_args : dict or kwargs
             Any keyword arguments to pass to the statsmodels ARIMA fit.
         """
+        # #530: catch callers still passing the pre-2.0 `exog` kwarg before
+        # it gets swallowed by **fit_args (statsmodels.fit doesn't take
+        # `exog` either, so it would silently disappear without effect).
+        X = _resolve_legacy_exog_kwarg("fit", X, fit_args)
         y = check_endog(y, dtype=DTYPE, preserve_series=True)
         n_samples = y.shape[0]
 
@@ -703,6 +737,10 @@ class ARIMA(BaseARIMA):
         """
         check_is_fitted(self, 'arima_res_')
 
+        # #530: catch the pre-2.0 `exog` kwarg before it gets swallowed by
+        # **kwargs and silently dropped by the statsmodels predict() call.
+        X = _resolve_legacy_exog_kwarg("predict_in_sample", X, kwargs)
+
         # issue #499: support prediction with non-integer start/end indices
         # issue #286: we can't produce valid preds for start < diff value
         # we can only do the validation for issue 286 if `start` is an int
@@ -750,7 +788,7 @@ class ARIMA(BaseARIMA):
                 X=None,
                 return_conf_int=False,
                 alpha=0.05,
-                **kwargs):  # TODO: remove kwargs after exog disappears
+                **kwargs):  # kwargs retained for legacy `exog=`; see #530
         """Forecast future values
 
         Generate predictions (forecasts) ``n_periods`` in the future.
@@ -787,6 +825,11 @@ class ARIMA(BaseARIMA):
         check_is_fitted(self, 'arima_res_')
         if not isinstance(n_periods, int):
             raise TypeError("n_periods must be an int")
+
+        # #530: catch the pre-2.0 `exog` kwarg before it falls into kwargs
+        # and gets silently dropped (predict() doesn't forward kwargs to
+        # statsmodels, so the value would just be ignored).
+        X = _resolve_legacy_exog_kwarg("predict", X, kwargs)
 
         # if we fit with exog, make sure one was passed:
         X = self._check_exog(X)  # type: np.ndarray
@@ -927,6 +970,11 @@ class ARIMA(BaseARIMA):
         """
         check_is_fitted(self, 'arima_res_')
         model_res = self.arima_res_
+
+        # #530: catch the pre-2.0 `exog` kwarg before it gets folded into
+        # **kwargs and forwarded to _fit, where statsmodels would silently
+        # drop it.
+        X = _resolve_legacy_exog_kwarg("update", X, kwargs)
 
         # Allow updating with a scalar if the user is just adding a single
         # sample.

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -759,3 +759,69 @@ def test_ARMAtoMA():
     equivalent_ma = ARMAtoMA(ar, ma, max_deg)
     ema_expected = np.array([0.9000, 1.3500, 1.3150, 1.5175, 1.5477, 1.6843])
     assert_array_almost_equal(equivalent_ma, ema_expected, decimal=4)
+
+
+# Issue #530 — pre-2.0 `exog` kwarg is silently swallowed by **kwargs.
+# These tests pin the new behaviour: the legacy name still works (so user
+# code from < 2.0 doesn't silently produce wrong predictions) but emits a
+# DeprecationWarning, and combining `X=` with `exog=` is a TypeError.
+def test_issue_530_fit_legacy_exog_kwarg_emits_deprecation():
+    rng = np.random.RandomState(530)
+    y_local = rng.randn(80)
+    X_local = rng.randn(80, 2)
+
+    # AFTER (this PR): fit(y, exog=X) succeeds, with a DeprecationWarning,
+    # and the model behaves like fit(y, X=X). On master the kwarg was
+    # silently dropped, so the model would behave like fit(y) — different
+    # parameters and different predictions, but no error or warning.
+    model_legacy = ARIMA(order=(1, 0, 0), suppress_warnings=True)
+    with pytest.warns(DeprecationWarning, match="`exog` keyword"):
+        model_legacy.fit(y_local, exog=X_local)
+    assert model_legacy.fit_with_exog_ is True
+
+    model_new = ARIMA(order=(1, 0, 0), suppress_warnings=True)
+    model_new.fit(y_local, X=X_local)
+    assert_array_almost_equal(model_legacy.params(), model_new.params())
+
+
+def test_issue_530_fit_both_X_and_exog_is_error():
+    rng = np.random.RandomState(531)
+    y_local = rng.randn(40)
+    X_local = rng.randn(40, 1)
+    model = ARIMA(order=(1, 0, 0), suppress_warnings=True)
+    # Defensive: passing both names is ambiguous and should fail loudly.
+    with pytest.raises(TypeError, match="both `X` and the deprecated alias"):
+        model.fit(y_local, X=X_local, exog=X_local)
+
+
+def test_issue_530_predict_legacy_exog_kwarg_emits_deprecation():
+    rng = np.random.RandomState(532)
+    y_local = rng.randn(80)
+    X_train = rng.randn(80, 2)
+    X_test = rng.randn(5, 2)
+
+    model = ARIMA(order=(1, 0, 0), suppress_warnings=True)
+    model.fit(y_local, X=X_train)
+
+    # AFTER: predict(n_periods, exog=X) warns and uses the value as X.
+    with pytest.warns(DeprecationWarning, match="`exog` keyword"):
+        preds_legacy = model.predict(n_periods=5, exog=X_test)
+    preds_new = model.predict(n_periods=5, X=X_test)
+    assert_array_almost_equal(preds_legacy, preds_new)
+
+
+def test_issue_530_update_legacy_exog_kwarg_emits_deprecation():
+    rng = np.random.RandomState(533)
+    y_train = rng.randn(80)
+    X_train = rng.randn(80, 2)
+    y_extra = rng.randn(10)
+    X_extra = rng.randn(10, 2)
+
+    model = ARIMA(order=(1, 0, 0), suppress_warnings=True)
+    model.fit(y_train, X=X_train)
+    with pytest.warns(DeprecationWarning, match="`exog` keyword"):
+        model.update(y_extra, exog=X_extra, maxiter=1)
+    # Successful update bumps nobs; if exog had been silently dropped, the
+    # update would have raised in _check_exog because the model was fit
+    # with X but called without one.
+    assert model.arima_res_.nobs == 90


### PR DESCRIPTION
# Description

`pmdarima.arima.ARIMA.fit` / `predict` / `update` / `predict_in_sample`
all accept `**fit_args` / `**kwargs` for forwarding to statsmodels.
Before pmdarima 2.0 the exogenous-features argument was named `exog`;
in 2.0 it was renamed to `X`. Because the methods kept their `**kwargs`
signature, callers passing `exog=foo` (e.g. legacy code that pre-dates
the rename) had it **silently swallowed**:

* `fit()` forwards kwargs to `_fit` then to statsmodels' `SARIMAX.fit`,
  which doesn't take an `exog` keyword on the fit() side either.
* `predict()` doesn't even forward kwargs, it just accepts them.
* `update()` and `predict_in_sample()` likewise drop unknown kwargs into
  the void.

Net effect: the user's intended exogenous matrix never reached the
model, the fit/forecast came out as if `X=None` had been passed, and
no warning was raised. There's a `# TODO: remove kwargs after exog
disappears` comment in `arima.py:753` acknowledging the situation.

This PR introduces a single private helper
`_resolve_legacy_exog_kwarg(method_name, X, kwargs)` that:

1. Pops `exog` from kwargs.
2. Raises `TypeError` if both `X` and `exog` are supplied (ambiguous).
3. Otherwise emits a `DeprecationWarning` and returns the legacy value
   so the method continues as if the caller had passed `X=...`.

It's wired into all four entry points: `fit`, `predict`, `update`,
`predict_in_sample`. `**kwargs` itself is **not** removed because
`predict_in_sample` actively forwards extras to statsmodels'
`get_prediction`, and `_fit` passes them to the SARIMAX constructor —
removing it would be a separate, larger breaking change.

Fixes #530

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

This is non-breaking for the documented contract: callers who already
use `X=...` (the post-2.0 way) see no change. Callers passing `exog=...`
now get correct behaviour with a `DeprecationWarning` instead of
silently-wrong predictions, which is an improvement either way.

## How Has This Been Tested?

```bash
pytest pmdarima/arima/tests/test_arima.py -k issue_530 -v
```

→ 4 new tests, all pass on this branch and all fail on `origin/master`:

* `test_issue_530_fit_legacy_exog_kwarg_emits_deprecation` — passing
  `fit(y, exog=X)` warns and produces parameters identical to
  `fit(y, X=X)`. On master, no warning, and parameters differ because
  the X is silently dropped.
* `test_issue_530_fit_both_X_and_exog_is_error` — `TypeError` on the
  ambiguous call.
* `test_issue_530_predict_legacy_exog_kwarg_emits_deprecation` — same
  for `predict(n_periods, exog=...)`.
* `test_issue_530_update_legacy_exog_kwarg_emits_deprecation` — same
  for `update(y, exog=...)`. Without the fix, `_check_exog` raises
  because the model was fit with X but called without one.

I also ran the full `test_arima.py` (57 tests) on this branch — all
pass.

# Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/alkaline-ml/pmdarima.git /tmp/repro && cd /tmp/repro
python -m venv .venv && source .venv/bin/activate
pip install -e . pytest

# --- BEFORE (origin/master) ---
git checkout origin/master
python - <<'PY'
import warnings, numpy as np
from pmdarima.arima import ARIMA
rng = np.random.RandomState(0)
y, X = rng.randn(80), rng.randn(80, 2)

# Same call, two names — the post-2.0 form vs the pre-2.0 form.
m_X = ARIMA(order=(1, 0, 0), suppress_warnings=True).fit(y, X=X)
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    m_legacy = ARIMA(order=(1, 0, 0), suppress_warnings=True).fit(y, exog=X)
print("DeprecationWarning emitted?", any(issubclass(wi.category, DeprecationWarning) for wi in w))
print("Same parameters?", np.allclose(m_X.params(), m_legacy.params()))
PY
# Expected on master:
#   DeprecationWarning emitted? False
#   Same parameters? False               ← the legacy `exog=` kwarg was dropped!

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/pmdarima.git feat/530-warn-deprecated-exog-kwarg
git checkout FETCH_HEAD
pip install -e . --quiet
python - <<'PY'
import warnings, numpy as np
from pmdarima.arima import ARIMA
rng = np.random.RandomState(0)
y, X = rng.randn(80), rng.randn(80, 2)
m_X = ARIMA(order=(1, 0, 0), suppress_warnings=True).fit(y, X=X)
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    m_legacy = ARIMA(order=(1, 0, 0), suppress_warnings=True).fit(y, exog=X)
print("DeprecationWarning emitted?", any(issubclass(wi.category, DeprecationWarning) for wi in w))
print("Same parameters?", np.allclose(m_X.params(), m_legacy.params()))
PY
# Expected after fix:
#   DeprecationWarning emitted? True
#   Same parameters? True                ← legacy `exog=` is now correctly used as X
```

# Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | `fit(y, exog=X)` (legacy) | `y`, X | warn + same params as `fit(y, X=X)` | `test_issue_530_fit_legacy_exog_kwarg_emits_deprecation` |
| 2 | `fit(y, X=X, exog=X)` | both | `TypeError` | `test_issue_530_fit_both_X_and_exog_is_error` |
| 3 | `predict(n, exog=X)` (legacy) | fitted model, X | warn + same preds as `predict(n, X=X)` | `test_issue_530_predict_legacy_exog_kwarg_emits_deprecation` |
| 4 | `update(y, exog=X)` (legacy) | fitted model | warn + nobs grows correctly | `test_issue_530_update_legacy_exog_kwarg_emits_deprecation` |
| 5 | `fit(y, X=X)` (current) | y, X | unchanged behaviour | full `test_arima.py` (57 passed) |

# Risk / blast radius

* Adds one private helper at module scope, four 2-line wiring blocks at
  the four entry points.
* No public API renamed or removed. Callers using `X=` see no change.
* Callers using `exog=` move from "silently wrong" to "warned-and-correct".
* Callers passing both names in error get a clear `TypeError` instead
  of a silent fallback.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (the
      `# TODO: remove kwargs after exog disappears` comment in `predict`
      is replaced with a note pointing at #530)
- [x] My changes generate no new warnings (`pytest test_arima.py` clean)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (57/57 in
      `test_arima.py`)

```release-note
ARIMA.fit / predict / update / predict_in_sample now emit a DeprecationWarning instead of silently swallowing the legacy pre-2.0 `exog=` keyword (#530).
```

---

*PR drafted with assistance from Claude Code. Reviewed manually against
`pmdarima/arima/arima.py` (the four entry points) and the existing
`force_all_finite` -> `ensure_all_finite` sentinel in the same file.
Reproducer block above was used during development.*
