### PR TITLE
[MRG] base: split exogenous X across train and forecast in fit_predict (#514)

### DIFF
--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -759,3 +759,49 @@ def test_ARMAtoMA():
     equivalent_ma = ARMAtoMA(ar, ma, max_deg)
     ema_expected = np.array([0.9000, 1.3500, 1.3150, 1.5175, 1.5477, 1.6843])
     assert_array_almost_equal(equivalent_ma, ema_expected, decimal=4)
+
+
+# Issue #514 — fit_predict used to pass the same X to fit() and predict(),
+# so any caller supplying exogenous features hit
+# `ValueError: X array dims (n_rows) != n_periods` because predict()
+# required X.shape[0] == n_periods while fit() required X.shape[0] == len(y).
+# After the fix, the caller passes one X covering the training window plus
+# the forecast horizon, fit_predict splits it, and the call succeeds.
+def test_issue_514_fit_predict_with_X_splits_train_and_forecast():
+    rng = np.random.RandomState(514)
+    y_local = rng.randn(60)
+    n_periods = 5
+    # Combined X covering training (60 rows) + forecast horizon (5 rows).
+    X_local = rng.randn(60 + n_periods, 2)
+
+    model = ARIMA(order=(1, 0, 0), suppress_warnings=True)
+    preds = model.fit_predict(y_local, X=X_local, n_periods=n_periods)
+    assert preds.shape == (n_periods,)
+
+    # The split must match what the user gets from fitting + predicting
+    # manually. Same RNG seed → same MLE start, same fit, same predictions.
+    model2 = ARIMA(order=(1, 0, 0), suppress_warnings=True)
+    model2.fit(y_local, X=X_local[:60])
+    preds2 = model2.predict(n_periods=n_periods, X=X_local[60:])
+    assert_array_almost_equal(preds, preds2)
+
+
+def test_issue_514_fit_predict_X_wrong_length_raises_clear_error():
+    rng = np.random.RandomState(515)
+    y_local = rng.randn(60)
+    # Wrong: X covers only the training window, not the forecast horizon.
+    X_local = rng.randn(60, 2)
+
+    model = ARIMA(order=(1, 0, 0), suppress_warnings=True)
+    with pytest.raises(ValueError, match="must cover both the training"):
+        model.fit_predict(y_local, X=X_local, n_periods=5)
+
+
+def test_issue_514_fit_predict_no_X_still_works():
+    """Pure-endogenous fit_predict was the only path that worked before
+    the fix; this guards that the no-X short-circuit didn't regress."""
+    rng = np.random.RandomState(516)
+    y_local = rng.randn(40)
+    model = ARIMA(order=(1, 0, 0), suppress_warnings=True)
+    preds = model.fit_predict(y_local, n_periods=7)
+    assert preds.shape == (7,)

--- a/pmdarima/base.py
+++ b/pmdarima/base.py
@@ -32,11 +32,13 @@ class BaseARIMA(BaseEstimator, metaclass=ABCMeta):
             ``np.nan`` or ``np.inf`` values.
 
         X : array-like, shape=[n_obs, n_vars], optional (default=None)
-            An optional 2-d array of exogenous variables. If provided, these
-            variables are used as additional features in the regression
-            operation. This should not include a constant or trend. Note that
-            if an ``ARIMA`` is fit on exogenous features, it must be provided
-            exogenous features for making predictions.
+            An optional 2-d array of exogenous variables. If provided, ``X``
+            must contain rows for **both** the training observations and
+            the ``n_periods`` future periods to forecast — i.e.
+            ``X.shape[0] == len(y) + n_periods``. ``fit_predict`` will use
+            the first ``len(y)`` rows for fitting and the last
+            ``n_periods`` rows for forecasting. This should not include a
+            constant or trend.
 
         n_periods : int, optional (default=10)
             The number of periods in the future to forecast.
@@ -44,10 +46,41 @@ class BaseARIMA(BaseEstimator, metaclass=ABCMeta):
         fit_args : dict or kwargs, optional (default=None)
             Any keyword args to pass to the fit method.
         """
-        self.fit(y, X, **fit_args)
+        # Issue #514: previously the SAME `X` was passed to both fit() and
+        # predict(), which raised inside predict because predict requires
+        # X.shape[0] == n_periods while fit requires X.shape[0] == len(y).
+        # Require the caller to provide one combined X covering both the
+        # training window and the forecast horizon, and split it here. The
+        # `X is None` short-circuit preserves the no-exog code path used by
+        # most callers (and the existing ARIMA/AutoARIMA tests).
+        X_fit, X_pred = X, X
+        if X is not None:
+            n_train = len(y) if hasattr(y, "__len__") else getattr(y, "shape", (0,))[0]
+            expected = n_train + n_periods
+            if getattr(X, "shape", (0,))[0] != expected:
+                raise ValueError(
+                    f"When X is provided to fit_predict, it must cover both "
+                    f"the training samples and the forecast horizon: "
+                    f"expected X.shape[0] == len(y) + n_periods "
+                    f"({n_train} + {n_periods} = {expected}), got "
+                    f"{getattr(X, 'shape', (0,))[0]}. If you only have X for "
+                    f"the training window, call fit(y, X) and predict("
+                    f"n_periods, X=X_future) separately."
+                )
+            # Use iloc when available (pandas) so the index is preserved on
+            # both halves; numpy slicing falls back to the second branch.
+            if hasattr(X, "iloc"):
+                X_fit = X.iloc[:n_train]
+                X_pred = X.iloc[n_train:]
+            else:
+                X_fit = X[:n_train]
+                X_pred = X[n_train:]
 
-        # TODO: remove kwargs from call
-        return self.predict(n_periods=n_periods, X=X, **fit_args)
+        self.fit(y, X_fit, **fit_args)
+        # fit_args is intentionally NOT forwarded to predict; predict's
+        # signature only forwards extras to statsmodels' get_prediction, and
+        # most fit_args (e.g. method=, start_params=) would error there.
+        return self.predict(n_periods=n_periods, X=X_pred)
 
     # TODO: remove kwargs from all of these
 

--- a/pmdarima/base.py
+++ b/pmdarima/base.py
@@ -55,7 +55,10 @@ class BaseARIMA(BaseEstimator, metaclass=ABCMeta):
         # most callers (and the existing ARIMA/AutoARIMA tests).
         X_fit, X_pred = X, X
         if X is not None:
-            n_train = len(y) if hasattr(y, "__len__") else getattr(y, "shape", (0,))[0]
+            n_train = (
+                len(y) if hasattr(y, "__len__")
+                else getattr(y, "shape", (0,))[0]
+            )
             expected = n_train + n_periods
             if getattr(X, "shape", (0,))[0] != expected:
                 raise ValueError(


### PR DESCRIPTION
# Description

`BaseARIMA.fit_predict` forwarded the **same** `X` to both `fit()` and
`predict()`:

```python
self.fit(y, X, **fit_args)
return self.predict(n_periods=n_periods, X=X, **fit_args)
```

That can't compose. `fit()` requires `X.shape[0] == len(y)`,
`predict()` requires `X.shape[0] == n_periods`. So any caller supplying
exogenous features hit
`ValueError: X array dims (n_rows) != n_periods` from
`pmdarima/arima/arima.py:794`. The pure-endogenous path was the only
one that ever worked.

This PR adopts the contract the issue reporter proposed: when `X` is
supplied, require it to cover both the training samples and the
forecast horizon (`X.shape[0] == len(y) + n_periods`), and split it
inside `fit_predict` — the first `len(y)` rows go to `fit()`, the last
`n_periods` rows go to `predict()`. The no-X path is unchanged. A clear
`ValueError` covers the "X is the wrong length" case so users with only
a training-window X get pointed at the explicit
`fit(...) + predict(...)` flow.

I also dropped `**fit_args` from the inner `predict()` call — `predict`
forwards extras to statsmodels' `get_prediction`, which doesn't accept
fit-time options like `method=` or `start_params=` that callers pass
to `fit_predict`. Forwarding them was a latent bug surfaced by the same
test reproducer.

Fixes #514

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Strictly speaking the previous behaviour with X was "always raised", so
the user-visible contract changes from "always crashes" to "works as
documented". Pure-endogenous callers see no change.

## How Has This Been Tested?

```bash
pytest pmdarima/arima/tests/test_arima.py -k issue_514 -v
```

→ 3 new tests, all pass on this branch:

* `test_issue_514_fit_predict_with_X_splits_train_and_forecast` — the
  happy path: pass an X covering 60+5 rows and verify the predictions
  match `fit(y, X[:60]) + predict(5, X[60:])` exactly.
* `test_issue_514_fit_predict_X_wrong_length_raises_clear_error` —
  passing X of length len(y) raises a clear `ValueError`.
* `test_issue_514_fit_predict_no_X_still_works` — the pure-endogenous
  path is preserved.

The first two **fail** on `origin/master` (the happy path with the
`ValueError: X array dims != n_periods`, the wrong-length test with a
different — and confusing — error message). The third passes on master
because that path was never broken. The full `test_arima.py` (56 tests
existing + 3 new = 59) passes on this branch (one unrelated BoxCox
failure in `test_pipeline.py` was pre-existing on `origin/master` and
is not covered by this PR).

# Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/alkaline-ml/pmdarima.git /tmp/repro && cd /tmp/repro
python -m venv .venv && source .venv/bin/activate
pip install -e . pytest

# --- BEFORE (origin/master) ---
git checkout origin/master
python - <<'PY'
import numpy as np
from pmdarima.arima import ARIMA
rng = np.random.RandomState(514)
y = rng.randn(60)
X = rng.randn(60 + 5, 2)        # X covering train (60) + horizon (5)
m = ARIMA(order=(1, 0, 0), suppress_warnings=True)
try:
    preds = m.fit_predict(y, X=X, n_periods=5)
    print("preds:", preds.shape)
except Exception as e:
    print("FAILED:", type(e).__name__, "-", e)
PY
# Expected on master:
#   FAILED: ValueError - X array dims (n_rows) != n_periods. Received n_rows=65 and n_periods=5

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/pmdarima.git feat/514-fit-predict-split-X
git checkout FETCH_HEAD
pip install -e . --quiet
python - <<'PY'
import numpy as np
from pmdarima.arima import ARIMA
rng = np.random.RandomState(514)
y = rng.randn(60)
X = rng.randn(60 + 5, 2)
m = ARIMA(order=(1, 0, 0), suppress_warnings=True)
preds = m.fit_predict(y, X=X, n_periods=5)
print("preds:", preds.shape, "→ first 3:", preds[:3])
PY
# Expected after fix:
#   preds: (5,) → first 3: [...3 floats...]
```

# Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Combined X (train + horizon) | `y[60]`, `X[65, 2]`, `n_periods=5` | `(5,)` preds, identical to fit-then-predict | `test_issue_514_fit_predict_with_X_splits_train_and_forecast` |
| 2 | X too short | `y[60]`, `X[60, 2]`, `n_periods=5` | clear `ValueError` referencing the contract | `test_issue_514_fit_predict_X_wrong_length_raises_clear_error` |
| 3 | No X (pure endog) | `y[40]`, `X=None`, `n_periods=7` | `(7,)` preds, unchanged behaviour | `test_issue_514_fit_predict_no_X_still_works` |

# Risk / blast radius

* Single method in a single file (`pmdarima/base.py`) plus 3 tests.
* The signature is unchanged — only the internal X-handling logic
  switches from "duplicate" to "split". Callers who previously hit the
  ValueError now get correct predictions; callers who used
  fit_predict without X see no difference.
* A `pandas.iloc` branch keeps the index alignment when `X` is a
  DataFrame (the original code passed it through opaquely).

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (the
      `fit_predict` docstring now describes the train+horizon contract)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

```release-note
fit_predict now correctly splits the supplied exogenous X into a training slice and a forecast-horizon slice rather than passing the same array to both fit() and predict() and crashing (#514).
```

---

*PR drafted with assistance from Claude Code. The split logic matches
the fix proposed by the original reporter in #514. Reviewed against
`pmdarima/base.py` and `pmdarima/arima/arima.py` predict-side X
validation.*
